### PR TITLE
Add presupuestos module

### DIFF
--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -70,6 +70,20 @@ JWT_SECRET=supersecreto123
 - `PUT /api/productos/:id` – Editar producto
 - `DELETE /api/productos/:id` – Eliminar producto
 
+### Ventas
+- `POST /api/ventas` – Crear venta
+- `GET /api/ventas` – Listar ventas
+- `GET /api/ventas/:id` – Ver venta
+- `PUT /api/ventas/:id` – Editar venta
+- `DELETE /api/ventas/:id` – Eliminar venta
+
+### Presupuestos
+- `POST /api/presupuestos` – Crear presupuesto
+- `GET /api/presupuestos` – Listar presupuestos
+- `GET /api/presupuestos/:id` – Ver presupuesto
+- `PUT /api/presupuestos/:id` – Editar presupuesto
+- `DELETE /api/presupuestos/:id` – Eliminar presupuesto
+
 ---
 
 ## 🧪 Middleware incluidos

--- a/backend/app.js
+++ b/backend/app.js
@@ -41,4 +41,10 @@ app.use('/api/clientes', clientesRoutes);
 const proveedoresRoutes = require('./routes/proveedores');
 app.use('/api/proveedores', proveedoresRoutes);
 
+const ventasRoutes = require('./routes/ventas');
+app.use('/api/ventas', ventasRoutes);
+
+const presupuestosRoutes = require('./routes/presupuestos');
+app.use('/api/presupuestos', presupuestosRoutes);
+
 module.exports = app;

--- a/backend/controllers/presupuestoController.js
+++ b/backend/controllers/presupuestoController.js
@@ -1,0 +1,62 @@
+const Presupuesto = require('../models/Presupuesto');
+
+const obtenerPresupuestos = async (req, res) => {
+  try {
+    const presupuestos = await Presupuesto.find()
+      .populate('cliente')
+      .populate('productos.producto');
+    res.json(presupuestos);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener presupuestos', error: error.message });
+  }
+};
+
+const obtenerPresupuesto = async (req, res) => {
+  try {
+    const presupuesto = await Presupuesto.findById(req.params.id)
+      .populate('cliente')
+      .populate('productos.producto');
+    if (!presupuesto) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+    res.json(presupuesto);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener presupuesto', error: error.message });
+  }
+};
+
+const crearPresupuesto = async (req, res) => {
+  try {
+    const presupuesto = new Presupuesto(req.body);
+    const guardado = await presupuesto.save();
+    res.status(201).json(guardado);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear presupuesto', error: error.message });
+  }
+};
+
+const actualizarPresupuesto = async (req, res) => {
+  try {
+    const actualizado = await Presupuesto.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!actualizado) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+    res.json(actualizado);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar presupuesto', error: error.message });
+  }
+};
+
+const eliminarPresupuesto = async (req, res) => {
+  try {
+    const eliminado = await Presupuesto.findByIdAndDelete(req.params.id);
+    if (!eliminado) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+    res.json({ mensaje: 'Presupuesto eliminado' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar presupuesto', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerPresupuestos,
+  obtenerPresupuesto,
+  crearPresupuesto,
+  actualizarPresupuesto,
+  eliminarPresupuesto
+};

--- a/backend/controllers/ventaController.js
+++ b/backend/controllers/ventaController.js
@@ -1,0 +1,62 @@
+const Venta = require('../models/Venta');
+
+const obtenerVentas = async (req, res) => {
+  try {
+    const ventas = await Venta.find()
+      .populate('cliente')
+      .populate('productos.producto');
+    res.json(ventas);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener ventas', error: error.message });
+  }
+};
+
+const obtenerVenta = async (req, res) => {
+  try {
+    const venta = await Venta.findById(req.params.id)
+      .populate('cliente')
+      .populate('productos.producto');
+    if (!venta) return res.status(404).json({ mensaje: 'Venta no encontrada' });
+    res.json(venta);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener venta', error: error.message });
+  }
+};
+
+const crearVenta = async (req, res) => {
+  try {
+    const venta = new Venta(req.body);
+    const ventaGuardada = await venta.save();
+    res.status(201).json(ventaGuardada);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear venta', error: error.message });
+  }
+};
+
+const actualizarVenta = async (req, res) => {
+  try {
+    const ventaActualizada = await Venta.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!ventaActualizada) return res.status(404).json({ mensaje: 'Venta no encontrada' });
+    res.json(ventaActualizada);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar venta', error: error.message });
+  }
+};
+
+const eliminarVenta = async (req, res) => {
+  try {
+    const ventaEliminada = await Venta.findByIdAndDelete(req.params.id);
+    if (!ventaEliminada) return res.status(404).json({ mensaje: 'Venta no encontrada' });
+    res.json({ mensaje: 'Venta eliminada' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar venta', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerVentas,
+  obtenerVenta,
+  crearVenta,
+  actualizarVenta,
+  eliminarVenta
+};

--- a/backend/models/Presupuesto.js
+++ b/backend/models/Presupuesto.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const presupuestoSchema = new mongoose.Schema({
+  cliente: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente', required: true },
+  productos: [
+    {
+      producto: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto', required: true },
+      cantidad: { type: Number, required: true, min: 1 },
+      precio: { type: Number, required: true }
+    }
+  ],
+  total: { type: Number, required: true },
+  fecha: { type: Date, default: Date.now },
+  estado: {
+    type: String,
+    enum: ['pendiente', 'aprobado', 'rechazado'],
+    default: 'pendiente'
+  }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Presupuesto', presupuestoSchema);

--- a/backend/models/Venta.js
+++ b/backend/models/Venta.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const ventaSchema = new mongoose.Schema({
+  cliente: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente', required: true },
+  productos: [
+    {
+      producto: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto', required: true },
+      cantidad: { type: Number, required: true, min: 1 },
+      precio: { type: Number, required: true }
+    }
+  ],
+  total: { type: Number, required: true },
+  fecha: { type: Date, default: Date.now },
+  notas: String
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Venta', ventaSchema);

--- a/backend/routes/presupuestos.js
+++ b/backend/routes/presupuestos.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerPresupuestos,
+  obtenerPresupuesto,
+  crearPresupuesto,
+  actualizarPresupuesto,
+  eliminarPresupuesto
+} = require('../controllers/presupuestoController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerPresupuestos);
+router.get('/:id', verificarToken, obtenerPresupuesto);
+router.post('/', verificarToken, permitirRoles('admin', 'ventas'), crearPresupuesto);
+router.put('/:id', verificarToken, permitirRoles('admin', 'ventas'), actualizarPresupuesto);
+router.delete('/:id', verificarToken, permitirRoles('admin'), eliminarPresupuesto);
+
+module.exports = router;

--- a/backend/routes/ventas.js
+++ b/backend/routes/ventas.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerVentas,
+  obtenerVenta,
+  crearVenta,
+  actualizarVenta,
+  eliminarVenta
+} = require('../controllers/ventaController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerVentas);
+router.get('/:id', verificarToken, obtenerVenta);
+router.post('/', verificarToken, permitirRoles('admin', 'ventas'), crearVenta);
+router.put('/:id', verificarToken, permitirRoles('admin', 'ventas'), actualizarVenta);
+router.delete('/:id', verificarToken, permitirRoles('admin'), eliminarVenta);
+
+module.exports = router;

--- a/frontend/README_frontend.md
+++ b/frontend/README_frontend.md
@@ -70,6 +70,12 @@ frontend/
 - `/dashboard/productos`
 - `/dashboard/productos/nuevo`
 - `/dashboard/productos/editar/:id`
+- `/dashboard/ventas`
+- `/dashboard/ventas/nueva`
+- `/dashboard/ventas/editar/:id`
+- `/dashboard/presupuestos`
+- `/dashboard/presupuestos/nuevo`
+- `/dashboard/presupuestos/editar/:id`
 
 ---
 

--- a/frontend/src/components/FormularioPresupuesto.jsx
+++ b/frontend/src/components/FormularioPresupuesto.jsx
@@ -1,0 +1,69 @@
+function FormularioPresupuesto({ presupuesto, setPresupuesto, productos, handleSubmit, esEdicion = false }) {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setPresupuesto({
+      ...presupuesto,
+      [name]: value
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Cliente</label>
+        <input
+          type="text"
+          name="cliente"
+          value={presupuesto.cliente}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+          required
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Producto</label>
+        <select
+          name="producto"
+          value={presupuesto.producto}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+          required
+        >
+          <option value="">-- Seleccionar --</option>
+          {productos.map((p) => (
+            <option key={p._id} value={p._id}>{p.nombre}</option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block font-semibold mb-1">Cantidad</label>
+          <input
+            type="number"
+            name="cantidad"
+            value={presupuesto.cantidad}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Precio</label>
+          <input
+            type="number"
+            name="precio"
+            value={presupuesto.precio}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+      </div>
+      <button className="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">
+        {esEdicion ? 'Guardar cambios' : 'Guardar presupuesto'}
+      </button>
+    </form>
+  );
+}
+
+export default FormularioPresupuesto;

--- a/frontend/src/components/FormularioVenta.jsx
+++ b/frontend/src/components/FormularioVenta.jsx
@@ -1,0 +1,65 @@
+function FormularioVenta({ venta, setVenta, handleSubmit, esEdicion = false }) {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setVenta({
+      ...venta,
+      [name]: value
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Cliente</label>
+        <input
+          type="text"
+          name="cliente"
+          value={venta.cliente}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+          required
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Producto</label>
+        <input
+          type="text"
+          name="producto"
+          value={venta.producto}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+          required
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block font-semibold mb-1">Cantidad</label>
+          <input
+            type="number"
+            name="cantidad"
+            value={venta.cantidad}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Precio</label>
+          <input
+            type="number"
+            name="precio"
+            value={venta.precio}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+      </div>
+      <button className="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">
+        {esEdicion ? 'Guardar cambios' : 'Registrar venta'}
+      </button>
+    </form>
+  );
+}
+
+export default FormularioVenta;

--- a/frontend/src/layout/DashboardLayout.jsx
+++ b/frontend/src/layout/DashboardLayout.jsx
@@ -21,6 +21,8 @@ function DashboardLayout({ children }) {
           )}
 
           <Link to="/dashboard/productos" className="hover:text-blue-300">Productos</Link>
+          <Link to="/dashboard/ventas" className="hover:text-blue-300">Ventas</Link>
+          <Link to="/dashboard/presupuestos" className="hover:text-blue-300">Presupuestos</Link>
           <Link to="/dashboard/clientes" className="hover:text-blue-300">Clientes</Link>
           <Link to="/dashboard/proveedores" className="hover:text-blue-300">Proveedores</Link>
         </nav>
@@ -47,6 +49,8 @@ function DashboardLayout({ children }) {
           <Link to="/dashboard" className="hover:text-blue-300" onClick={() => setSidebarOpen(false)}>Inicio</Link>
           <Link to="/dashboard/usuarios" className="hover:text-blue-300" onClick={() => setSidebarOpen(false)}>Usuarios</Link>
           <Link to="/dashboard/productos" className="hover:text-blue-300" onClick={() => setSidebarOpen(false)}>Productos</Link>
+          <Link to="/dashboard/ventas" className="hover:text-blue-300" onClick={() => setSidebarOpen(false)}>Ventas</Link>
+          <Link to="/dashboard/presupuestos" className="hover:text-blue-300" onClick={() => setSidebarOpen(false)}>Presupuestos</Link>
         </nav>
         <button
           onClick={() => { logout(); setSidebarOpen(false); }}

--- a/frontend/src/pages/presupuestos/EditarPresupuesto.jsx
+++ b/frontend/src/pages/presupuestos/EditarPresupuesto.jsx
@@ -1,0 +1,74 @@
+import { useContext, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+import FormularioPresupuesto from '../../components/FormularioPresupuesto';
+
+function EditarPresupuesto() {
+  const { token } = useContext(AuthContext);
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [presupuesto, setPresupuesto] = useState({
+    cliente: '',
+    producto: '',
+    cantidad: 1,
+    precio: 0
+  });
+  const [productos, setProductos] = useState([]);
+  const [mensaje, setMensaje] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const cargarDatos = async () => {
+      try {
+        const [pres, prods] = await Promise.all([
+          clienteAxios.get(`/presupuestos/${id}`, { headers: { Authorization: `Bearer ${token}` } }),
+          clienteAxios.get('/productos', { headers: { Authorization: `Bearer ${token}` } })
+        ]);
+        setPresupuesto({
+          cliente: pres.data.cliente,
+          producto: pres.data.producto,
+          cantidad: pres.data.cantidad,
+          precio: pres.data.precio
+        });
+        setProductos(prods.data);
+      } catch (err) {
+        setError('Error al cargar presupuesto');
+      }
+    };
+    cargarDatos();
+  }, [id, token]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMensaje('');
+    setError('');
+    try {
+      await clienteAxios.put(`/presupuestos/${id}`, presupuesto, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setMensaje('Presupuesto actualizado');
+      setTimeout(() => navigate('/dashboard/presupuestos'), 2000);
+    } catch (err) {
+      setError('Error al actualizar presupuesto');
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">Editar presupuesto</h2>
+      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <FormularioPresupuesto
+        presupuesto={presupuesto}
+        setPresupuesto={setPresupuesto}
+        productos={productos}
+        handleSubmit={handleSubmit}
+        esEdicion
+      />
+    </div>
+  );
+}
+
+export default EditarPresupuesto;

--- a/frontend/src/pages/presupuestos/NuevoPresupuesto.jsx
+++ b/frontend/src/pages/presupuestos/NuevoPresupuesto.jsx
@@ -1,0 +1,65 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+import { useNavigate } from 'react-router-dom';
+import FormularioPresupuesto from '../../components/FormularioPresupuesto';
+
+function NuevoPresupuesto() {
+  const { token } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [presupuesto, setPresupuesto] = useState({
+    cliente: '',
+    producto: '',
+    cantidad: 1,
+    precio: 0
+  });
+  const [productos, setProductos] = useState([]);
+  const [mensaje, setMensaje] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const cargarProductos = async () => {
+      try {
+        const { data } = await clienteAxios.get('/productos', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setProductos(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    cargarProductos();
+  }, [token]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMensaje('');
+    setError('');
+    try {
+      await clienteAxios.post('/presupuestos', presupuesto, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setMensaje('Presupuesto guardado');
+      setTimeout(() => navigate('/dashboard/presupuestos'), 2000);
+    } catch (err) {
+      setError('Error al guardar presupuesto');
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">Nuevo presupuesto</h2>
+      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <FormularioPresupuesto
+        presupuesto={presupuesto}
+        setPresupuesto={setPresupuesto}
+        productos={productos}
+        handleSubmit={handleSubmit}
+      />
+    </div>
+  );
+}
+
+export default NuevoPresupuesto;

--- a/frontend/src/pages/presupuestos/Presupuestos.jsx
+++ b/frontend/src/pages/presupuestos/Presupuestos.jsx
@@ -1,0 +1,90 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+import { Link } from 'react-router-dom';
+
+function Presupuestos() {
+  const { token } = useContext(AuthContext);
+  const [presupuestos, setPresupuestos] = useState([]);
+
+  useEffect(() => {
+    const obtener = async () => {
+      try {
+        const { data } = await clienteAxios.get('/presupuestos', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setPresupuestos(data);
+      } catch (err) {
+        console.error('Error al obtener presupuestos', err);
+      }
+    };
+    obtener();
+  }, [token]);
+
+  const handleEliminar = async (id) => {
+    if (!confirm('¿Eliminar este presupuesto?')) return;
+    try {
+      await clienteAxios.delete(`/presupuestos/${id}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setPresupuestos(prev => prev.filter(p => p._id !== id));
+    } catch (err) {
+      alert('Error al eliminar presupuesto');
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4 flex-wrap gap-4">
+        <h2 className="text-2xl font-bold">Presupuestos</h2>
+        <Link
+          to="/dashboard/presupuestos/nuevo"
+          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+        >
+          + Nuevo Presupuesto
+        </Link>
+      </div>
+
+      <div className="overflow-x-auto bg-white rounded shadow">
+        <table className="min-w-full text-left">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="p-3">Cliente</th>
+              <th className="p-3">Producto</th>
+              <th className="p-3">Cantidad</th>
+              <th className="p-3">Precio</th>
+              <th className="p-3">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {presupuestos.map(p => (
+              <tr key={p._id} className="border-b hover:bg-gray-50">
+                <td className="p-3">{p.cliente}</td>
+                <td className="p-3">{p.producto}</td>
+                <td className="p-3">{p.cantidad}</td>
+                <td className="p-3">${p.precio}</td>
+                <td className="p-3 flex gap-2 text-sm">
+                  <Link to={`/dashboard/presupuestos/editar/${p._id}`} className="text-blue-600 hover:underline">
+                    Editar
+                  </Link>
+                  <button onClick={() => handleEliminar(p._id)} className="text-red-600 hover:underline">
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {presupuestos.length === 0 && (
+              <tr>
+                <td colSpan="5" className="text-center p-4 text-gray-500">
+                  No hay presupuestos registrados
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Presupuestos;

--- a/frontend/src/pages/ventas/EditarVenta.jsx
+++ b/frontend/src/pages/ventas/EditarVenta.jsx
@@ -1,0 +1,67 @@
+import { useContext, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+import FormularioVenta from '../../components/FormularioVenta';
+
+function EditarVenta() {
+  const { token } = useContext(AuthContext);
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [venta, setVenta] = useState({
+    cliente: '',
+    producto: '',
+    cantidad: 1,
+    precio: 0
+  });
+
+  const [mensaje, setMensaje] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const obtenerVenta = async () => {
+      try {
+        const { data } = await clienteAxios.get(`/ventas/${id}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setVenta({
+          cliente: data.cliente,
+          producto: data.producto,
+          cantidad: data.cantidad,
+          precio: data.precio
+        });
+      } catch (err) {
+        setError('Error al cargar la venta');
+      }
+    };
+    obtenerVenta();
+  }, [id, token]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMensaje('');
+    setError('');
+
+    try {
+      await clienteAxios.put(`/ventas/${id}`, venta, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setMensaje('Venta actualizada');
+      setTimeout(() => navigate('/dashboard/ventas'), 2000);
+    } catch (err) {
+      setError('Error al actualizar venta');
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">Editar venta</h2>
+      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <FormularioVenta venta={venta} setVenta={setVenta} handleSubmit={handleSubmit} esEdicion />
+    </div>
+  );
+}
+
+export default EditarVenta;

--- a/frontend/src/pages/ventas/NuevaVenta.jsx
+++ b/frontend/src/pages/ventas/NuevaVenta.jsx
@@ -1,0 +1,47 @@
+import { useContext, useState } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+import { useNavigate } from 'react-router-dom';
+import FormularioVenta from '../../components/FormularioVenta';
+
+function NuevaVenta() {
+  const { token } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [venta, setVenta] = useState({
+    cliente: '',
+    producto: '',
+    cantidad: 1,
+    precio: 0
+  });
+
+  const [mensaje, setMensaje] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMensaje('');
+    setError('');
+
+    try {
+      await clienteAxios.post('/ventas', venta, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setMensaje('Venta registrada correctamente');
+      setTimeout(() => navigate('/dashboard/ventas'), 2000);
+    } catch (err) {
+      setError('Error al registrar venta');
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">Registrar venta</h2>
+      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <FormularioVenta venta={venta} setVenta={setVenta} handleSubmit={handleSubmit} />
+    </div>
+  );
+}
+
+export default NuevaVenta;

--- a/frontend/src/pages/ventas/Ventas.jsx
+++ b/frontend/src/pages/ventas/Ventas.jsx
@@ -1,0 +1,90 @@
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+import { Link } from 'react-router-dom';
+
+function Ventas() {
+  const { token } = useContext(AuthContext);
+  const [ventas, setVentas] = useState([]);
+
+  useEffect(() => {
+    const obtenerVentas = async () => {
+      try {
+        const { data } = await clienteAxios.get('/ventas', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setVentas(data);
+      } catch (error) {
+        console.error('Error al obtener ventas', error);
+      }
+    };
+    obtenerVentas();
+  }, [token]);
+
+  const handleEliminar = async (id) => {
+    if (!confirm('¿Eliminar esta venta?')) return;
+    try {
+      await clienteAxios.delete(`/ventas/${id}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setVentas(prev => prev.filter(v => v._id !== id));
+    } catch (error) {
+      alert('Error al eliminar venta');
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4 flex-wrap gap-4">
+        <h2 className="text-2xl font-bold">Ventas</h2>
+        <Link
+          to="/dashboard/ventas/nueva"
+          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+        >
+          + Nueva Venta
+        </Link>
+      </div>
+
+      <div className="overflow-x-auto bg-white rounded shadow">
+        <table className="min-w-full text-left">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="p-3">Cliente</th>
+              <th className="p-3">Producto</th>
+              <th className="p-3">Cantidad</th>
+              <th className="p-3">Precio</th>
+              <th className="p-3">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ventas.map(venta => (
+              <tr key={venta._id} className="border-b hover:bg-gray-50">
+                <td className="p-3">{venta.cliente}</td>
+                <td className="p-3">{venta.producto}</td>
+                <td className="p-3">{venta.cantidad}</td>
+                <td className="p-3">${venta.precio}</td>
+                <td className="p-3 flex gap-2 text-sm">
+                  <Link to={`/dashboard/ventas/editar/${venta._id}`} className="text-blue-600 hover:underline">
+                    Editar
+                  </Link>
+                  <button onClick={() => handleEliminar(venta._id)} className="text-red-600 hover:underline">
+                    Eliminar
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {ventas.length === 0 && (
+              <tr>
+                <td colSpan="5" className="text-center p-4 text-gray-500">
+                  No hay ventas registradas
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Ventas;

--- a/frontend/src/routes/AppRoute.jsx
+++ b/frontend/src/routes/AppRoute.jsx
@@ -24,6 +24,12 @@ import NotFound from '../pages/NotFound';
 import Proveedores from '../pages/proveedores/Proveedores';
 import EditarProveedor from '../pages/proveedores/EditarProveedores';
 import NuevoProveedor from '../pages/proveedores/NuevoProveedor';
+import Ventas from '../pages/ventas/Ventas';
+import NuevaVenta from '../pages/ventas/NuevaVenta';
+import EditarVenta from '../pages/ventas/EditarVenta';
+import Presupuestos from '../pages/presupuestos/Presupuestos';
+import NuevoPresupuesto from '../pages/presupuestos/NuevoPresupuesto';
+import EditarPresupuesto from '../pages/presupuestos/EditarPresupuesto';
 
 function AppRoutes() {
   return (
@@ -173,6 +179,68 @@ function AppRoutes() {
           <PrivateRoute>
             <DashboardLayout>
               <EditarProveedor />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+
+      <Route
+        path="/dashboard/ventas"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <Ventas />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/ventas/nueva"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <NuevaVenta />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/ventas/editar/:id"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <EditarVenta />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+
+      <Route
+        path="/dashboard/presupuestos"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <Presupuestos />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/presupuestos/nuevo"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <NuevoPresupuesto />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/presupuestos/editar/:id"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <EditarPresupuesto />
             </DashboardLayout>
           </PrivateRoute>
         }


### PR DESCRIPTION
## Summary
- create Presupuesto model, controller and routes in backend
- register presupuestos routes
- document presupuestos endpoints
- add React pages and forms for presupuestos
- expose presupuestos navigation links and routes

## Testing
- `npm test` in backend *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68783136f2408333a294cde7365af594