### PR TITLE
Add sales module with quotes and invoices

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -44,4 +44,13 @@ app.use('/api/proveedores', proveedoresRoutes);
 const ventasRoutes = require('./routes/ventas');
 app.use('/api/ventas', ventasRoutes);
 
+const presupuestosRoutes = require('./routes/presupuestos');
+app.use('/api/presupuestos', presupuestosRoutes);
+
+const facturasRoutes = require('./routes/facturas');
+app.use('/api/facturas', facturasRoutes);
+
+const pagosRoutes = require('./routes/pagos');
+app.use('/api/pagos', pagosRoutes);
+
 module.exports = app;

--- a/backend/controllers/facturaController.js
+++ b/backend/controllers/facturaController.js
@@ -1,0 +1,62 @@
+const Factura = require('../models/Factura');
+const Pago = require('../models/Pago');
+
+const obtenerFacturas = async (req, res) => {
+  try {
+    const facturas = await Factura.find().populate('venta');
+    res.json(facturas);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener facturas', error: error.message });
+  }
+};
+
+const obtenerFactura = async (req, res) => {
+  try {
+    const factura = await Factura.findById(req.params.id).populate('venta');
+    if (!factura) return res.status(404).json({ mensaje: 'Factura no encontrada' });
+    res.json(factura);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener factura', error: error.message });
+  }
+};
+
+const crearFactura = async (req, res) => {
+  try {
+    const ultima = await Factura.findOne().sort({ numero: -1 });
+    const numero = ultima ? ultima.numero + 1 : 1;
+    const factura = new Factura({ ...req.body, numero });
+    const guardada = await factura.save();
+    res.status(201).json(guardada);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear factura', error: error.message });
+  }
+};
+
+const actualizarFactura = async (req, res) => {
+  try {
+    const actualizada = await Factura.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!actualizada) return res.status(404).json({ mensaje: 'Factura no encontrada' });
+    res.json(actualizada);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar factura', error: error.message });
+  }
+};
+
+const eliminarFactura = async (req, res) => {
+  try {
+    const eliminada = await Factura.findByIdAndDelete(req.params.id);
+    if (!eliminada) return res.status(404).json({ mensaje: 'Factura no encontrada' });
+    await Pago.deleteMany({ factura: eliminada._id });
+    res.json({ mensaje: 'Factura eliminada' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar factura', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerFacturas,
+  obtenerFactura,
+  crearFactura,
+  actualizarFactura,
+  eliminarFactura
+};

--- a/backend/controllers/pagoController.js
+++ b/backend/controllers/pagoController.js
@@ -1,0 +1,34 @@
+const Pago = require('../models/Pago');
+const Factura = require('../models/Factura');
+
+const listarPagosPorFactura = async (req, res) => {
+  try {
+    const pagos = await Pago.find({ factura: req.params.facturaId });
+    res.json(pagos);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener pagos', error: error.message });
+  }
+};
+
+const crearPago = async (req, res) => {
+  try {
+    const pago = new Pago(req.body);
+    const guardado = await pago.save();
+    // actualizar estado factura
+    const pagos = await Pago.find({ factura: pago.factura });
+    const sum = pagos.reduce((acc, p) => acc + p.monto, 0);
+    const factura = await Factura.findById(pago.factura);
+    if (!factura) return res.status(404).json({ mensaje: 'Factura no encontrada' });
+    if (sum >= factura.total) factura.estado = 'pagada';
+    else factura.estado = 'parcial';
+    await factura.save();
+    res.status(201).json(guardado);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al registrar pago', error: error.message });
+  }
+};
+
+module.exports = {
+  listarPagosPorFactura,
+  crearPago
+};

--- a/backend/controllers/presupuestoController.js
+++ b/backend/controllers/presupuestoController.js
@@ -1,0 +1,62 @@
+const Presupuesto = require('../models/Presupuesto');
+
+const obtenerPresupuestos = async (req, res) => {
+  try {
+    const presupuestos = await Presupuesto.find()
+      .populate('cliente')
+      .populate('productos.producto');
+    res.json(presupuestos);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener presupuestos', error: error.message });
+  }
+};
+
+const obtenerPresupuesto = async (req, res) => {
+  try {
+    const presupuesto = await Presupuesto.findById(req.params.id)
+      .populate('cliente')
+      .populate('productos.producto');
+    if (!presupuesto) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+    res.json(presupuesto);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener presupuesto', error: error.message });
+  }
+};
+
+const crearPresupuesto = async (req, res) => {
+  try {
+    const presupuesto = new Presupuesto(req.body);
+    const guardado = await presupuesto.save();
+    res.status(201).json(guardado);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear presupuesto', error: error.message });
+  }
+};
+
+const actualizarPresupuesto = async (req, res) => {
+  try {
+    const actualizado = await Presupuesto.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!actualizado) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+    res.json(actualizado);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar presupuesto', error: error.message });
+  }
+};
+
+const eliminarPresupuesto = async (req, res) => {
+  try {
+    const eliminado = await Presupuesto.findByIdAndDelete(req.params.id);
+    if (!eliminado) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+    res.json({ mensaje: 'Presupuesto eliminado' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar presupuesto', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerPresupuestos,
+  obtenerPresupuesto,
+  crearPresupuesto,
+  actualizarPresupuesto,
+  eliminarPresupuesto
+};

--- a/backend/models/Factura.js
+++ b/backend/models/Factura.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const facturaSchema = new mongoose.Schema({
+  venta: { type: mongoose.Schema.Types.ObjectId, ref: 'Venta', required: true },
+  numero: { type: Number, unique: true },
+  subtotal: { type: Number, required: true },
+  iva: { type: Number, required: true },
+  total: { type: Number, required: true },
+  estado: {
+    type: String,
+    enum: ['pendiente', 'pagada', 'parcial'],
+    default: 'pendiente'
+  },
+  fecha: { type: Date, default: Date.now }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Factura', facturaSchema);

--- a/backend/models/Pago.js
+++ b/backend/models/Pago.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const pagoSchema = new mongoose.Schema({
+  factura: { type: mongoose.Schema.Types.ObjectId, ref: 'Factura', required: true },
+  monto: { type: Number, required: true },
+  metodo: { type: String, default: 'efectivo' },
+  fecha: { type: Date, default: Date.now }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Pago', pagoSchema);

--- a/backend/models/Presupuesto.js
+++ b/backend/models/Presupuesto.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const presupuestoSchema = new mongoose.Schema({
+  cliente: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente', required: true },
+  productos: [
+    {
+      producto: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto' },
+      nombre: String,
+      cantidad: { type: Number, required: true },
+      precio: { type: Number, required: true },
+      subtotal: { type: Number, required: true }
+    }
+  ],
+  total: { type: Number, required: true },
+  fechaCreacion: { type: Date, default: Date.now },
+  validez: { type: Date },
+  estado: {
+    type: String,
+    enum: ['pendiente', 'aceptado', 'rechazado'],
+    default: 'pendiente'
+  }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Presupuesto', presupuestoSchema);

--- a/backend/models/Venta.js
+++ b/backend/models/Venta.js
@@ -9,6 +9,12 @@ const ventaSchema = new mongoose.Schema({
       precio: { type: Number, required: true }
     }
   ],
+  presupuesto: { type: mongoose.Schema.Types.ObjectId, ref: 'Presupuesto' },
+  estado: {
+    type: String,
+    enum: ['pendiente', 'procesando', 'completado', 'cancelado'],
+    default: 'pendiente'
+  },
   total: { type: Number, required: true },
   fecha: { type: Date, default: Date.now },
   notas: String

--- a/backend/routes/facturas.js
+++ b/backend/routes/facturas.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerFacturas,
+  obtenerFactura,
+  crearFactura,
+  actualizarFactura,
+  eliminarFactura
+} = require('../controllers/facturaController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerFacturas);
+router.get('/:id', verificarToken, obtenerFactura);
+router.post('/', verificarToken, permitirRoles('admin', 'ventas'), crearFactura);
+router.put('/:id', verificarToken, permitirRoles('admin', 'ventas'), actualizarFactura);
+router.delete('/:id', verificarToken, permitirRoles('admin'), eliminarFactura);
+
+module.exports = router;

--- a/backend/routes/pagos.js
+++ b/backend/routes/pagos.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+const { listarPagosPorFactura, crearPago } = require('../controllers/pagoController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/factura/:facturaId', verificarToken, listarPagosPorFactura);
+router.post('/', verificarToken, permitirRoles('admin', 'ventas'), crearPago);
+
+module.exports = router;

--- a/backend/routes/presupuestos.js
+++ b/backend/routes/presupuestos.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerPresupuestos,
+  obtenerPresupuesto,
+  crearPresupuesto,
+  actualizarPresupuesto,
+  eliminarPresupuesto
+} = require('../controllers/presupuestoController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerPresupuestos);
+router.get('/:id', verificarToken, obtenerPresupuesto);
+router.post('/', verificarToken, permitirRoles('admin', 'ventas'), crearPresupuesto);
+router.put('/:id', verificarToken, permitirRoles('admin', 'ventas'), actualizarPresupuesto);
+router.delete('/:id', verificarToken, permitirRoles('admin'), eliminarPresupuesto);
+
+module.exports = router;

--- a/frontend/src/components/FormularioPresupuesto.jsx
+++ b/frontend/src/components/FormularioPresupuesto.jsx
@@ -1,0 +1,73 @@
+function FormularioPresupuesto({ datos, setDatos, handleSubmit }) {
+  const handleChange = (e, index) => {
+    const { name, value } = e.target;
+    if (name.startsWith('producto')) {
+      const productos = [...datos.productos];
+      const field = name.split('.')[1];
+      productos[index][field] = value;
+      setDatos({ ...datos, productos });
+    } else {
+      setDatos({ ...datos, [name]: value });
+    }
+  };
+
+  const agregarProducto = () => {
+    setDatos({
+      ...datos,
+      productos: [...datos.productos, { nombre: '', cantidad: 1, precio: 0, subtotal: 0 }]
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Cliente</label>
+        <input
+          type="text"
+          name="cliente"
+          value={datos.cliente}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+          required
+        />
+      </div>
+
+      {datos.productos.map((prod, idx) => (
+        <div key={idx} className="grid grid-cols-4 gap-2 items-end">
+          <input
+            type="text"
+            name={`producto.nombre`}
+            placeholder="Producto"
+            value={prod.nombre}
+            onChange={(e) => handleChange({ ...e, target: { ...e.target, name: 'producto.nombre' } }, idx)}
+            className="p-2 border rounded"
+          />
+          <input
+            type="number"
+            name={`producto.cantidad`}
+            placeholder="Cant"
+            value={prod.cantidad}
+            onChange={(e) => handleChange({ ...e, target: { ...e.target, name: 'producto.cantidad' } }, idx)}
+            className="p-2 border rounded"
+          />
+          <input
+            type="number"
+            name={`producto.precio`}
+            placeholder="Precio"
+            value={prod.precio}
+            onChange={(e) => handleChange({ ...e, target: { ...e.target, name: 'producto.precio' } }, idx)}
+            className="p-2 border rounded"
+          />
+        </div>
+      ))}
+
+      <button type="button" onClick={agregarProducto} className="bg-gray-200 px-3 py-1 rounded">
+        + Producto
+      </button>
+
+      <button className="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">Guardar</button>
+    </form>
+  );
+}
+
+export default FormularioPresupuesto;

--- a/frontend/src/pages/facturas/Facturas.jsx
+++ b/frontend/src/pages/facturas/Facturas.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+
+function Facturas() {
+  const { token } = useContext(AuthContext);
+  const [facturas, setFacturas] = useState([]);
+
+  useEffect(() => {
+    const obtener = async () => {
+      try {
+        const { data } = await clienteAxios.get('/facturas', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setFacturas(data);
+      } catch (error) {
+        console.error('Error al obtener facturas', error);
+      }
+    };
+    obtener();
+  }, [token]);
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-6">Facturas</h2>
+      <div className="overflow-x-auto bg-white rounded shadow">
+        <table className="min-w-full text-left">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="p-3">Número</th>
+              <th className="p-3">Cliente</th>
+              <th className="p-3">Total</th>
+              <th className="p-3">Estado</th>
+            </tr>
+          </thead>
+          <tbody>
+            {facturas.map(f => (
+              <tr key={f._id} className="border-b hover:bg-gray-50">
+                <td className="p-3">{f.numero}</td>
+                <td className="p-3">{f.venta?.cliente}</td>
+                <td className="p-3">${f.total}</td>
+                <td className="p-3">{f.estado}</td>
+              </tr>
+            ))}
+            {facturas.length === 0 && (
+              <tr>
+                <td colSpan="4" className="text-center p-4 text-gray-500">No hay facturas</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default Facturas;

--- a/frontend/src/pages/presupuestos/NuevoPresupuesto.jsx
+++ b/frontend/src/pages/presupuestos/NuevoPresupuesto.jsx
@@ -1,0 +1,42 @@
+import { useContext, useState } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+import { useNavigate } from 'react-router-dom';
+import FormularioPresupuesto from '../../components/FormularioPresupuesto';
+
+function NuevoPresupuesto() {
+  const { token } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [datos, setDatos] = useState({
+    cliente: '',
+    productos: [
+      { nombre: '', cantidad: 1, precio: 0, subtotal: 0 }
+    ],
+    total: 0,
+    estado: 'pendiente'
+  });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const productos = datos.productos.map(p => ({ ...p, subtotal: p.cantidad * p.precio }));
+      const total = productos.reduce((acc, p) => acc + p.subtotal, 0);
+      await clienteAxios.post('/presupuestos', { ...datos, productos, total }, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      navigate('/dashboard/presupuestos');
+    } catch (error) {
+      alert('Error al crear presupuesto');
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">Nuevo Presupuesto</h2>
+      <FormularioPresupuesto datos={datos} setDatos={setDatos} handleSubmit={handleSubmit} />
+    </div>
+  );
+}
+
+export default NuevoPresupuesto;

--- a/frontend/src/pages/presupuestos/Presupuestos.jsx
+++ b/frontend/src/pages/presupuestos/Presupuestos.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState, useContext } from 'react';
+import { AuthContext } from '../../context/AuthContext';
+import clienteAxios from '../../api/clienteAxios';
+import { Link } from 'react-router-dom';
+
+function Presupuestos() {
+  const { token } = useContext(AuthContext);
+  const [presupuestos, setPresupuestos] = useState([]);
+
+  useEffect(() => {
+    const obtener = async () => {
+      try {
+        const { data } = await clienteAxios.get('/presupuestos', {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setPresupuestos(data);
+      } catch (error) {
+        console.error('Error al obtener presupuestos', error);
+      }
+    };
+    obtener();
+  }, [token]);
+
+  const handleEliminar = async (id) => {
+    if (!confirm('¿Eliminar este presupuesto?')) return;
+    try {
+      await clienteAxios.delete(`/presupuestos/${id}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setPresupuestos(prev => prev.filter(p => p._id !== id));
+    } catch (error) {
+      alert('Error al eliminar presupuesto');
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 gap-3">
+        <h2 className="text-2xl font-bold">Presupuestos</h2>
+        <Link
+          to="/dashboard/presupuestos/nuevo"
+          className="bg-green-600 text-white px-4 py-2 rounded-xl hover:bg-blue-700 transition"
+        >
+          + Nuevo Presupuesto
+        </Link>
+      </div>
+
+      {presupuestos.length === 0 ? (
+        <p className="text-gray-500">No hay presupuestos cargados aún.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {presupuestos.map(p => (
+            <div key={p._id} className="bg-white rounded-2xl shadow p-5 space-y-2 hover:shadow-md transition">
+              <h3 className="text-lg font-semibold text-gray-800">{p.cliente?.nombre}</h3>
+              <p className="text-sm text-gray-600">Estado: {p.estado}</p>
+              <p className="text-sm text-gray-600">Total: ${p.total}</p>
+              <div className="pt-3 flex justify-end gap-4 text-sm">
+                <button onClick={() => handleEliminar(p._id)} className="text-red-600 hover:underline">Eliminar</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Presupuestos;

--- a/frontend/src/routes/AppRoute.jsx
+++ b/frontend/src/routes/AppRoute.jsx
@@ -27,6 +27,9 @@ import NuevoProveedor from '../pages/proveedores/NuevoProveedor';
 import Ventas from '../pages/ventas/Ventas';
 import NuevaVenta from '../pages/ventas/NuevaVenta';
 import EditarVenta from '../pages/ventas/EditarVenta';
+import Presupuestos from '../pages/presupuestos/Presupuestos';
+import NuevoPresupuesto from '../pages/presupuestos/NuevoPresupuesto';
+import Facturas from '../pages/facturas/Facturas';
 
 function AppRoutes() {
   return (
@@ -207,6 +210,36 @@ function AppRoutes() {
           <PrivateRoute>
             <DashboardLayout>
               <EditarVenta />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/presupuestos"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <Presupuestos />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/presupuestos/nuevo"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <NuevoPresupuesto />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/facturas"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <Facturas />
             </DashboardLayout>
           </PrivateRoute>
         }


### PR DESCRIPTION
## Summary
- create models for Presupuesto, Factura and Pago
- extend Venta model with estado and presupuesto
- add controllers and routes for presupuestos, facturas and pagos
- wire new routes in backend app
- add budget form component and pages for Presupuestos and Facturas
- register new pages in React router

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687abb9918a88333a74058f4aafd4bf9