### PR TITLE
Implement multi-tenant sign up

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -37,6 +37,9 @@ app.use('/api/protegida', protegidaRoutes);
 const productoRoutes = require('./routes/productRoutes');
 app.use('/api/productos', productoRoutes);
 
+const empresasRoutes = require('./routes/empresas');
+app.use('/api/empresas', empresasRoutes);
+
 const clientesRoutes = require('./routes/clientes');
 app.use('/api/clientes', clientesRoutes);
 

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -19,7 +19,8 @@ const loginUsuario = async (req, res) => {
     const token = jwt.sign(
       {
         id: usuario._id,
-        rol: usuario.rol
+        rol: usuario.rol,
+        empresaId: usuario.empresaId
       },
       process.env.JWT_SECRET,
       { expiresIn: '2h' }
@@ -32,7 +33,8 @@ const loginUsuario = async (req, res) => {
         id: usuario._id,
         nombre: usuario.nombre,
         email: usuario.email,
-        rol: usuario.rol
+        rol: usuario.rol,
+        empresaId: usuario.empresaId
       }
     });
   } catch (error) {

--- a/backend/controllers/clienteController.js
+++ b/backend/controllers/clienteController.js
@@ -3,7 +3,7 @@ const Cliente = require('../models/Cliente');
 
 const obtenerClientes = async (req, res) => {
   try {
-    const clientes = await Cliente.find();
+    const clientes = await Cliente.find({ empresaId: req.empresaId });
     res.json(clientes);
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al obtener clientes', error: error.message });

--- a/backend/controllers/empresaController.js
+++ b/backend/controllers/empresaController.js
@@ -1,0 +1,26 @@
+const Empresa = require('../models/Empresa');
+const User = require('../models/User');
+
+const crearEmpresaDemo = async (req, res) => {
+  const { nombre, plan, colorPrimario, subdominio, nombreUsuario, emailUsuario, contraseña } = req.body;
+
+  try {
+    const empresa = new Empresa({ nombre, plan, colorPrimario, subdominio });
+    const empresaGuardada = await empresa.save();
+
+    const user = new User({
+      nombre: nombreUsuario,
+      email: emailUsuario,
+      contraseña,
+      rol: 'admin',
+      empresaId: empresaGuardada._id
+    });
+    await user.save();
+
+    res.status(201).json({ mensaje: 'Empresa y usuario creados' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear empresa', error: error.message });
+  }
+};
+
+module.exports = { crearEmpresaDemo };

--- a/backend/controllers/facturaController.js
+++ b/backend/controllers/facturaController.js
@@ -4,7 +4,7 @@ const Pago = require('../models/Pago');
 
 const obtenerFacturas = async (req, res) => {
   try {
-    const facturas = await Factura.find().populate('venta');
+    const facturas = await Factura.find({ empresaId: req.empresaId }).populate('venta');
     res.json(facturas);
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al obtener facturas', error: error.message });
@@ -13,7 +13,7 @@ const obtenerFacturas = async (req, res) => {
 
 const obtenerFactura = async (req, res) => {
   try {
-    const factura = await Factura.findById(req.params.id).populate('venta');
+    const factura = await Factura.findOne({ _id: req.params.id, empresaId: req.empresaId }).populate('venta');
     if (!factura) return res.status(404).json({ mensaje: 'Factura no encontrada' });
     res.json(factura);
   } catch (error) {
@@ -23,9 +23,9 @@ const obtenerFactura = async (req, res) => {
 
 const crearFactura = async (req, res) => {
   try {
-    const ultima = await Factura.findOne().sort({ numero: -1 });
+    const ultima = await Factura.findOne({ empresaId: req.empresaId }).sort({ numero: -1 });
     const numero = ultima ? ultima.numero + 1 : 1;
-    const factura = new Factura({ ...req.body, numero });
+    const factura = new Factura({ ...req.body, empresaId: req.empresaId, numero });
     const guardada = await factura.save();
     res.status(201).json(guardada);
   } catch (error) {
@@ -35,7 +35,7 @@ const crearFactura = async (req, res) => {
 
 const actualizarFactura = async (req, res) => {
   try {
-    const actualizada = await Factura.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const actualizada = await Factura.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, { new: true });
     if (!actualizada) return res.status(404).json({ mensaje: 'Factura no encontrada' });
     res.json(actualizada);
   } catch (error) {
@@ -45,7 +45,7 @@ const actualizarFactura = async (req, res) => {
 
 const eliminarFactura = async (req, res) => {
   try {
-    const eliminada = await Factura.findByIdAndDelete(req.params.id);
+    const eliminada = await Factura.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
     if (!eliminada) return res.status(404).json({ mensaje: 'Factura no encontrada' });
     await Pago.deleteMany({ factura: eliminada._id });
     res.json({ mensaje: 'Factura eliminada' });

--- a/backend/controllers/pagoController.js
+++ b/backend/controllers/pagoController.js
@@ -4,7 +4,7 @@ const Factura = require('../models/Factura');
 
 const listarPagosPorFactura = async (req, res) => {
   try {
-    const pagos = await Pago.find({ factura: req.params.facturaId });
+    const pagos = await Pago.find({ factura: req.params.facturaId, empresaId: req.empresaId });
     res.json(pagos);
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al obtener pagos', error: error.message });
@@ -13,12 +13,12 @@ const listarPagosPorFactura = async (req, res) => {
 
 const crearPago = async (req, res) => {
   try {
-    const pago = new Pago(req.body);
+    const pago = new Pago({ ...req.body, empresaId: req.empresaId });
     const guardado = await pago.save();
     // actualizar estado factura
-    const pagos = await Pago.find({ factura: pago.factura });
+    const pagos = await Pago.find({ factura: pago.factura, empresaId: req.empresaId });
     const sum = pagos.reduce((acc, p) => acc + p.monto, 0);
-    const factura = await Factura.findById(pago.factura);
+    const factura = await Factura.findOne({ _id: pago.factura, empresaId: req.empresaId });
     if (!factura) return res.status(404).json({ mensaje: 'Factura no encontrada' });
     if (sum >= factura.total) factura.estado = 'pagada';
     else factura.estado = 'parcial';

--- a/backend/controllers/presupuestoController.js
+++ b/backend/controllers/presupuestoController.js
@@ -3,7 +3,7 @@ const Presupuesto = require('../models/Presupuesto');
 
 const obtenerPresupuestos = async (req, res) => {
   try {
-    const presupuestos = await Presupuesto.find()
+    const presupuestos = await Presupuesto.find({ empresaId: req.empresaId })
       .populate('cliente')
       .populate('productos.producto');
     res.json(presupuestos);
@@ -14,7 +14,7 @@ const obtenerPresupuestos = async (req, res) => {
 
 const obtenerPresupuesto = async (req, res) => {
   try {
-    const presupuesto = await Presupuesto.findById(req.params.id)
+    const presupuesto = await Presupuesto.findOne({ _id: req.params.id, empresaId: req.empresaId })
       .populate('cliente')
       .populate('productos.producto');
     if (!presupuesto) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
@@ -26,7 +26,7 @@ const obtenerPresupuesto = async (req, res) => {
 
 const crearPresupuesto = async (req, res) => {
   try {
-    const presupuesto = new Presupuesto(req.body);
+    const presupuesto = new Presupuesto({ ...req.body, empresaId: req.empresaId });
     const guardado = await presupuesto.save();
     res.status(201).json(guardado);
   } catch (error) {
@@ -36,7 +36,7 @@ const crearPresupuesto = async (req, res) => {
 
 const actualizarPresupuesto = async (req, res) => {
   try {
-    const actualizado = await Presupuesto.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const actualizado = await Presupuesto.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, { new: true });
     if (!actualizado) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
     res.json(actualizado);
   } catch (error) {
@@ -46,7 +46,7 @@ const actualizarPresupuesto = async (req, res) => {
 
 const eliminarPresupuesto = async (req, res) => {
   try {
-    const eliminado = await Presupuesto.findByIdAndDelete(req.params.id);
+    const eliminado = await Presupuesto.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
     if (!eliminado) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
     res.json({ mensaje: 'Presupuesto eliminado' });
   } catch (error) {

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -4,7 +4,7 @@ const Producto = require('../models/Product');
 // GET todos los productos
 const obtenerProductos = async (req, res) => {
   try {
-    const productos = await Producto.find();
+    const productos = await Producto.find({ empresaId: req.empresaId });
     res.json(productos);
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al obtener productos', error: error.message });
@@ -14,7 +14,7 @@ const obtenerProductos = async (req, res) => {
 // GET uno por ID
 const obtenerProducto = async (req, res) => {
   try {
-    const producto = await Producto.findById(req.params.id);
+    const producto = await Producto.findOne({ _id: req.params.id, empresaId: req.empresaId });
     if (!producto) {
       return res.status(404).json({ mensaje: 'Producto no encontrado' });
     }
@@ -27,7 +27,7 @@ const obtenerProducto = async (req, res) => {
 // POST nuevo
 const crearProducto = async (req, res) => {
   try {
-    const producto = new Producto(req.body);
+    const producto = new Producto({ ...req.body, empresaId: req.empresaId });
     await producto.save();
     res.status(201).json(producto);
   } catch (error) {
@@ -38,7 +38,7 @@ const crearProducto = async (req, res) => {
 // PUT actualizar
 const actualizarProducto = async (req, res) => {
   try {
-    const producto = await Producto.findByIdAndUpdate(req.params.id, req.body, {
+    const producto = await Producto.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, {
       new: true,
       runValidators: true
     });
@@ -54,7 +54,7 @@ const actualizarProducto = async (req, res) => {
 // DELETE
 const eliminarProducto = async (req, res) => {
   try {
-    const producto = await Producto.findByIdAndDelete(req.params.id);
+    const producto = await Producto.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
     if (!producto) {
       return res.status(404).json({ mensaje: 'Producto no encontrado' });
     }
@@ -69,6 +69,7 @@ const eliminarProducto = async (req, res) => {
     const productos = req.body;
 
     const insertables = productos.map(p => ({
+      empresaId: req.empresaId,
       nombre: p.nombre || '',
       sku: p.sku || '',
       precio: Number(p.precio) || 0,

--- a/backend/controllers/proveedorController.js
+++ b/backend/controllers/proveedorController.js
@@ -2,13 +2,13 @@
 const Proveedor = require('../models/Proveedor');
 
 const obtenerProveedores = async (req, res) => {
-  const proveedores = await Proveedor.find().sort({ createdAt: -1 });
+  const proveedores = await Proveedor.find({ empresaId: req.empresaId }).sort({ createdAt: -1 });
   res.json(proveedores);
 };
 
 const crearProveedor = async (req, res) => {
   try {
-    const proveedor = new Proveedor(req.body);
+    const proveedor = new Proveedor({ ...req.body, empresaId: req.empresaId });
     const proveedorGuardado = await proveedor.save();
     res.status(201).json(proveedorGuardado);
   } catch (error) {
@@ -18,7 +18,7 @@ const crearProveedor = async (req, res) => {
 
 const obtenerProveedor = async (req, res) => {
   try {
-    const proveedor = await Proveedor.findById(req.params.id);
+    const proveedor = await Proveedor.findOne({ _id: req.params.id, empresaId: req.empresaId });
     if (!proveedor) return res.status(404).json({ mensaje: 'Proveedor no encontrado' });
     res.json(proveedor);
   } catch (error) {
@@ -28,7 +28,7 @@ const obtenerProveedor = async (req, res) => {
 
 const actualizarProveedor = async (req, res) => {
   try {
-    const proveedorActualizado = await Proveedor.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const proveedorActualizado = await Proveedor.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, { new: true });
     res.json(proveedorActualizado);
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al actualizar proveedor', error: error.message });
@@ -37,7 +37,7 @@ const actualizarProveedor = async (req, res) => {
 
 const eliminarProveedor = async (req, res) => {
   try {
-    await Proveedor.findByIdAndDelete(req.params.id);
+    await Proveedor.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
     res.json({ mensaje: 'Proveedor eliminado' });
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al eliminar proveedor', error: error.message });

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -4,7 +4,7 @@ const User = require('../models/User');
 // Obtener todos los usuarios
 const obtenerUsuarios = async (req, res) => {
   try {
-    const usuarios = await User.find().select('-contraseña');
+    const usuarios = await User.find({ empresaId: req.empresaId }).select('-contraseña');
     res.json(usuarios);
   } catch (error) {
     res.status(500).json({ mensaje: 'Error al obtener usuarios', error: error.message });
@@ -21,7 +21,7 @@ const crearUsuario = async (req, res) => {
       return res.status(400).json({ mensaje: 'El usuario ya existe' });
     }
 
-    const nuevoUsuario = new User({ nombre, email, contraseña, rol });
+    const nuevoUsuario = new User({ nombre, email, contraseña, rol, empresaId: req.empresaId });
     await nuevoUsuario.save();
 
     res.status(201).json(nuevoUsuario);
@@ -33,7 +33,7 @@ const crearUsuario = async (req, res) => {
 // Obtener un usuario por ID
 const obtenerUsuarioPorId = async (req, res) => {
   try {
-    const usuario = await User.findById(req.params.id).select('-contraseña');
+    const usuario = await User.findOne({ _id: req.params.id, empresaId: req.empresaId }).select('-contraseña');
     if (!usuario) {
       return res.status(404).json({ mensaje: 'Usuario no encontrado' });
     }
@@ -46,7 +46,7 @@ const obtenerUsuarioPorId = async (req, res) => {
 // Actualizar un usuario
 const actualizarUsuario = async (req, res) => {
   try {
-    const usuarioActualizado = await User.findByIdAndUpdate(req.params.id, req.body, {
+    const usuarioActualizado = await User.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, {
       new: true,
       runValidators: true,
     }).select('-contraseña');
@@ -64,7 +64,7 @@ const actualizarUsuario = async (req, res) => {
 // Eliminar un usuario
 const eliminarUsuario = async (req, res) => {
   try {
-    const usuarioEliminado = await User.findByIdAndDelete(req.params.id);
+    const usuarioEliminado = await User.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
     if (!usuarioEliminado) {
       return res.status(404).json({ mensaje: 'Usuario no encontrado' });
     }

--- a/backend/controllers/ventaController.js
+++ b/backend/controllers/ventaController.js
@@ -3,7 +3,7 @@ const Venta = require('../models/Venta');
 
 const obtenerVentas = async (req, res) => {
   try {
-    const ventas = await Venta.find()
+    const ventas = await Venta.find({ empresaId: req.empresaId })
       .populate('cliente')
       .populate('productos.producto');
     res.json(ventas);
@@ -14,7 +14,7 @@ const obtenerVentas = async (req, res) => {
 
 const obtenerVenta = async (req, res) => {
   try {
-    const venta = await Venta.findById(req.params.id)
+    const venta = await Venta.findOne({ _id: req.params.id, empresaId: req.empresaId })
       .populate('cliente')
       .populate('productos.producto');
     if (!venta) return res.status(404).json({ mensaje: 'Venta no encontrada' });
@@ -26,7 +26,7 @@ const obtenerVenta = async (req, res) => {
 
 const crearVenta = async (req, res) => {
   try {
-    const venta = new Venta(req.body);
+    const venta = new Venta({ ...req.body, empresaId: req.empresaId });
     const ventaGuardada = await venta.save();
     res.status(201).json(ventaGuardada);
   } catch (error) {
@@ -36,7 +36,7 @@ const crearVenta = async (req, res) => {
 
 const actualizarVenta = async (req, res) => {
   try {
-    const ventaActualizada = await Venta.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const ventaActualizada = await Venta.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, { new: true });
     if (!ventaActualizada) return res.status(404).json({ mensaje: 'Venta no encontrada' });
     res.json(ventaActualizada);
   } catch (error) {
@@ -46,7 +46,7 @@ const actualizarVenta = async (req, res) => {
 
 const eliminarVenta = async (req, res) => {
   try {
-    const ventaEliminada = await Venta.findByIdAndDelete(req.params.id);
+    const ventaEliminada = await Venta.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
     if (!ventaEliminada) return res.status(404).json({ mensaje: 'Venta no encontrada' });
     res.json({ mensaje: 'Venta eliminada' });
   } catch (error) {
@@ -58,7 +58,7 @@ const Presupuesto = require('../models/Presupuesto');
 
 const crearVentaDesdePresupuesto = async (req, res) => {
   try {
-    const presupuesto = await Presupuesto.findById(req.params.id)
+    const presupuesto = await Presupuesto.findOne({ _id: req.params.id, empresaId: req.empresaId })
       .populate('cliente')
       .populate('productos.producto');
 
@@ -71,6 +71,7 @@ const crearVentaDesdePresupuesto = async (req, res) => {
     }
 
     const nuevaVenta = new Venta({
+      empresaId: req.empresaId,
       cliente: presupuesto.cliente._id,
       productos: presupuesto.productos.map(p => ({
         producto: p.producto?._id,

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -15,6 +15,7 @@ const verificarToken = (req, res, next) => {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.usuario = decoded; // lo dejamos disponible en la request
+    req.empresaId = decoded.empresaId;
     next();
   } catch (error) {
     return res.status(401).json({ mensaje: 'Token inválido o expirado' });

--- a/backend/models/Cliente.js
+++ b/backend/models/Cliente.js
@@ -2,6 +2,11 @@
 const mongoose = require('mongoose');
 
 const clienteSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   nombre: { type: String, required: true },
   email: { type: String },
   telefono: { type: String },

--- a/backend/models/Empresa.js
+++ b/backend/models/Empresa.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const empresaSchema = new mongoose.Schema({
+  nombre: {
+    type: String,
+    required: true
+  },
+  plan: String,
+  colorPrimario: String,
+  subdominio: {
+    type: String,
+    unique: true
+  },
+  fechaCreacion: {
+    type: Date,
+    default: Date.now
+  }
+});
+
+module.exports = mongoose.model('Empresa', empresaSchema);

--- a/backend/models/Factura.js
+++ b/backend/models/Factura.js
@@ -2,6 +2,11 @@
 const mongoose = require('mongoose');
 
 const facturaSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   venta: { type: mongoose.Schema.Types.ObjectId, ref: 'Venta', required: true },
   numero: { type: Number, unique: true },
   subtotal: { type: Number, required: true },

--- a/backend/models/Pago.js
+++ b/backend/models/Pago.js
@@ -2,6 +2,11 @@
 const mongoose = require('mongoose');
 
 const pagoSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   factura: { type: mongoose.Schema.Types.ObjectId, ref: 'Factura', required: true },
   monto: { type: Number, required: true },
   metodo: { type: String, default: 'efectivo' },

--- a/backend/models/Presupuesto.js
+++ b/backend/models/Presupuesto.js
@@ -2,6 +2,11 @@
 const mongoose = require('mongoose');
 
 const presupuestoSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   cliente: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente', required: true },
   productos: [
     {

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -2,6 +2,11 @@
 const mongoose = require('mongoose');
 
 const productoSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   nombre: { type: String, required: true },
   sku: { type: String, required: true, unique: true },
   stock: { type: Number, required: true, default: 0 },

--- a/backend/models/Proveedor.js
+++ b/backend/models/Proveedor.js
@@ -3,6 +3,11 @@
 const mongoose = require('mongoose');
 
 const proveedorSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   nombre: { type: String, required: true },
   email: String,
   telefono: String,

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -8,6 +8,11 @@ const userSchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   email: {
     type: String,
     required: true,

--- a/backend/models/Venta.js
+++ b/backend/models/Venta.js
@@ -2,6 +2,11 @@
 const mongoose = require('mongoose');
 
 const ventaSchema = new mongoose.Schema({
+  empresaId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Empresa',
+    required: true
+  },
   cliente: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente', required: true },
   productos: [
     {

--- a/backend/routes/clientes.js
+++ b/backend/routes/clientes.js
@@ -5,29 +5,29 @@ const Cliente = require('../models/Cliente');
 const { verificarToken }= require('../middleware/authMiddleware'); // Asegurate de tener este middleware
 
 router.get('/', verificarToken, async (req, res) => {
-  const clientes = await Cliente.find().sort({ createdAt: -1 });
+  const clientes = await Cliente.find({ empresaId: req.empresaId }).sort({ createdAt: -1 });
   res.json(clientes);
 });
 
 router.post('/', verificarToken, async (req, res) => {
-  const cliente = new Cliente(req.body);
+  const cliente = new Cliente({ ...req.body, empresaId: req.empresaId });
   await cliente.save();
   res.status(201).json(cliente);
 });
 
 router.get('/:id', verificarToken, async (req, res) => {
-  const cliente = await Cliente.findById(req.params.id);
+  const cliente = await Cliente.findOne({ _id: req.params.id, empresaId: req.empresaId });
   if (!cliente) return res.status(404).json({ mensaje: 'Cliente no encontrado' });
   res.json(cliente);
 });
 
 router.put('/:id', verificarToken, async (req, res) => {
-  const clienteActualizado = await Cliente.findByIdAndUpdate(req.params.id, req.body, { new: true });
+  const clienteActualizado = await Cliente.findOneAndUpdate({ _id: req.params.id, empresaId: req.empresaId }, req.body, { new: true });
   res.json(clienteActualizado);
 });
 
 router.delete('/:id', verificarToken, async (req, res) => {
-  await Cliente.findByIdAndDelete(req.params.id);
+  await Cliente.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
   res.json({ mensaje: 'Cliente eliminado' });
 });
 

--- a/backend/routes/empresas.js
+++ b/backend/routes/empresas.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { crearEmpresaDemo } = require('../controllers/empresaController');
+
+router.post('/', crearEmpresaDemo);
+
+module.exports = router;

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -11,11 +11,12 @@ const {
   actualizarUsuario,
   eliminarUsuario
 } = require('../controllers/userController');
+const { verificarToken } = require('../middleware/authMiddleware');
 
-router.get('/', obtenerUsuarios);
-router.post('/', crearUsuario);
-router.get('/:id', obtenerUsuarioPorId);
-router.put('/:id', actualizarUsuario);
-router.delete('/:id', eliminarUsuario);
+router.get('/', verificarToken, obtenerUsuarios);
+router.post('/', verificarToken, crearUsuario);
+router.get('/:id', verificarToken, obtenerUsuarioPorId);
+router.put('/:id', verificarToken, actualizarUsuario);
+router.delete('/:id', verificarToken, eliminarUsuario);
 
 module.exports = router;

--- a/frontend/src/layout/Header.jsx
+++ b/frontend/src/layout/Header.jsx
@@ -25,12 +25,12 @@ export default function Header() {
           >
             Iniciar Sesión
           </Link>
-          <a
-            href="#contacto"
+          <Link
+            to="/demo"
             className="bg-blue-800 text-white px-6 py-3 rounded shadow hover:bg-blue-900"
           >
             Solicitar Demo
-          </a>
+          </Link>
         </div>
       </header>
   )

--- a/frontend/src/pages/SolicitarDemo.jsx
+++ b/frontend/src/pages/SolicitarDemo.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import axios from 'axios';
+import Header from '../layout/Header';
+
+export default function SolicitarDemo() {
+  const [formulario, setFormulario] = useState({
+    nombreEmpresa: '',
+    plan: 'demo',
+    colorPrimario: '#4f46e5',
+    subdominio: '',
+    nombreUsuario: '',
+    emailUsuario: '',
+    contraseña: ''
+  });
+  const [mensaje, setMensaje] = useState('');
+  const [error, setError] = useState('');
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setFormulario({ ...formulario, [name]: value });
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setMensaje('');
+    setError('');
+    try {
+      await axios.post('http://localhost:5000/api/empresas', {
+        nombre: formulario.nombreEmpresa,
+        plan: formulario.plan,
+        colorPrimario: formulario.colorPrimario,
+        subdominio: formulario.subdominio,
+        nombreUsuario: formulario.nombreUsuario,
+        emailUsuario: formulario.emailUsuario,
+        contraseña: formulario.contraseña
+      });
+      setMensaje('Empresa creada correctamente. Ya podés iniciar sesión.');
+      setFormulario({
+        nombreEmpresa: '',
+        plan: 'demo',
+        colorPrimario: '#4f46e5',
+        subdominio: '',
+        nombreUsuario: '',
+        emailUsuario: '',
+        contraseña: ''
+      });
+    } catch (err) {
+      setError(err.response?.data?.mensaje || 'Error al crear empresa');
+    }
+  };
+
+  return (
+    <>
+      <Header />
+      <div className="max-w-xl mx-auto my-10 p-6 bg-white shadow rounded">
+        <h2 className="text-2xl font-bold mb-4 text-center">Solicitar Demo</h2>
+        {mensaje && <div className="bg-green-100 p-3 mb-4 text-green-800 rounded">{mensaje}</div>}
+        {error && <div className="bg-red-100 p-3 mb-4 text-red-800 rounded">{error}</div>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block mb-1">Nombre de la empresa</label>
+            <input
+              type="text"
+              name="nombreEmpresa"
+              value={formulario.nombreEmpresa}
+              onChange={handleChange}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Subdominio deseado</label>
+            <input
+              type="text"
+              name="subdominio"
+              value={formulario.subdominio}
+              onChange={handleChange}
+              className="w-full p-2 border rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Nombre del usuario administrador</label>
+            <input
+              type="text"
+              name="nombreUsuario"
+              value={formulario.nombreUsuario}
+              onChange={handleChange}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Email</label>
+            <input
+              type="email"
+              name="emailUsuario"
+              value={formulario.emailUsuario}
+              onChange={handleChange}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Contraseña</label>
+            <input
+              type="password"
+              name="contraseña"
+              value={formulario.contraseña}
+              onChange={handleChange}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+          <button type="submit" className="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">
+            Crear empresa
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/routes/AppRoute.jsx
+++ b/frontend/src/routes/AppRoute.jsx
@@ -7,6 +7,7 @@ import DashboardLayout from '../layout/DashboardLayout';
 
 import Login from '../pages/Login';
 import Landing from '../pages/Landing';
+import SolicitarDemo from '../pages/SolicitarDemo';
 
 import Usuarios from '../pages/usuarios/Usuarios';
 import NuevoUsuario from '../pages/usuarios/NuevoUsuario';
@@ -38,6 +39,7 @@ function AppRoutes() {
     <Routes>
       <Route path="/" element={<Landing />} />
       <Route path="/login" element={<Login />} />
+      <Route path="/demo" element={<SolicitarDemo />} />
 
       {/* Dashboard principal con KPIs */}
       <Route


### PR DESCRIPTION
## Summary
- add route and controller to create a company with an admin user
- register `/api/empresas` endpoint
- add page `SolicitarDemo` with form to create first company
- link "Solicitar Demo" button to new page and route

## Testing
- `npm test --prefix backend` *(fails: no test specified)*
- `npm test --prefix frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687dd03ccc548333bdeae646e6e50420