### PR TITLE
Fix presupuesto conversion

### DIFF
--- a/backend/controllers/ventaController.js
+++ b/backend/controllers/ventaController.js
@@ -70,15 +70,28 @@ const crearVentaDesdePresupuesto = async (req, res) => {
       return res.status(400).json({ mensaje: 'Solo se pueden convertir presupuestos aceptados en ventas' });
     }
 
-    const nuevaVenta = new Venta({
-      empresaId: req.empresaId,
-      cliente: presupuesto.cliente._id,
-      productos: presupuesto.productos.map(p => ({
-        producto: p.producto?._id,
+    if (!presupuesto.cliente) {
+      return res.status(400).json({ mensaje: 'El cliente asociado al presupuesto no existe' });
+    }
+
+    // Nos aseguramos de que todos los productos del presupuesto existan
+    const productosConvertidos = [];
+    for (const p of presupuesto.productos) {
+      if (!p.producto) {
+        return res.status(400).json({ mensaje: 'Uno o más productos ya no existen' });
+      }
+      productosConvertidos.push({
+        producto: p.producto._id || p.producto,
         cantidad: p.cantidad,
         precio: p.precio,
         subtotal: p.subtotal
-      })),
+      });
+    }
+
+    const nuevaVenta = new Venta({
+      empresaId: req.empresaId,
+      cliente: presupuesto.cliente._id,
+      productos: productosConvertidos,
       total: presupuesto.total
     });
 


### PR DESCRIPTION
## Summary
- prevent server crash when converting a presupuesto to venta
- verify cliente and productos exist before creating the venta

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687ed29fc54c8333b722efec4256ef87