### PR TITLE
Add tasks and production modules

### DIFF
--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -163,6 +163,7 @@ JWT_SECRET=supersecreto123
 - `inventario`
 - `rrhh`
 - `produccion`
+- `soporte`
 
 ---
 
@@ -177,6 +178,7 @@ JWT_SECRET=supersecreto123
 - Ventas creadas a partir de presupuestos aceptados
 - Pagos registrados
 - Inventario con movimientos de stock y reportes
+- Tareas y órdenes de producción
 ---
 
 ## 🧑‍💻 Autor

--- a/backend/app.js
+++ b/backend/app.js
@@ -61,6 +61,12 @@ app.use('/api/pagos', pagosRoutes);
 const movimientosRoutes = require('./routes/movimientos');
 app.use('/api/movimientos', movimientosRoutes);
 
+const tareasRoutes = require('./routes/tareas');
+app.use('/api/tareas', tareasRoutes);
+
+const ordenesRoutes = require('./routes/ordenes');
+app.use('/api/ordenes', ordenesRoutes);
+
 
 
 module.exports = app;

--- a/backend/controllers/ordenProduccionController.js
+++ b/backend/controllers/ordenProduccionController.js
@@ -1,0 +1,74 @@
+const OrdenProduccion = require('../models/OrdenProduccion');
+
+const calcularEstado = (etapas = []) => {
+  if (!etapas.length) return 'pendiente';
+  if (etapas.every(e => e.estado === 'completada')) return 'completada';
+  if (etapas.some(e => e.estado === 'en_progreso')) return 'en_progreso';
+  return 'pendiente';
+};
+
+const obtenerOrdenes = async (req, res) => {
+  try {
+    const ordenes = await OrdenProduccion.find({ empresaId: req.empresaId }).populate('producto');
+    res.json(ordenes);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener órdenes', error: error.message });
+  }
+};
+
+const obtenerOrden = async (req, res) => {
+  try {
+    const orden = await OrdenProduccion.findOne({ _id: req.params.id, empresaId: req.empresaId }).populate('producto');
+    if (!orden) return res.status(404).json({ mensaje: 'Orden no encontrada' });
+    res.json(orden);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener orden', error: error.message });
+  }
+};
+
+const crearOrden = async (req, res) => {
+  try {
+    const orden = new OrdenProduccion({ ...req.body, empresaId: req.empresaId });
+    orden.estadoGeneral = calcularEstado(orden.etapas);
+    await orden.save();
+    res.status(201).json(orden);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear orden', error: error.message });
+  }
+};
+
+const actualizarOrden = async (req, res) => {
+  try {
+    const data = { ...req.body };
+    if (data.etapas) {
+      data.estadoGeneral = calcularEstado(data.etapas);
+    }
+    const orden = await OrdenProduccion.findOneAndUpdate(
+      { _id: req.params.id, empresaId: req.empresaId },
+      data,
+      { new: true, runValidators: true }
+    );
+    if (!orden) return res.status(404).json({ mensaje: 'Orden no encontrada' });
+    res.json(orden);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar orden', error: error.message });
+  }
+};
+
+const eliminarOrden = async (req, res) => {
+  try {
+    const orden = await OrdenProduccion.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
+    if (!orden) return res.status(404).json({ mensaje: 'Orden no encontrada' });
+    res.json({ mensaje: 'Orden eliminada' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar orden', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerOrdenes,
+  obtenerOrden,
+  crearOrden,
+  actualizarOrden,
+  eliminarOrden
+};

--- a/backend/controllers/tareaController.js
+++ b/backend/controllers/tareaController.js
@@ -1,0 +1,62 @@
+const Tarea = require('../models/Tarea');
+
+const obtenerTareas = async (req, res) => {
+  try {
+    const tareas = await Tarea.find({ empresaId: req.empresaId });
+    res.json(tareas);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener tareas', error: error.message });
+  }
+};
+
+const obtenerTarea = async (req, res) => {
+  try {
+    const tarea = await Tarea.findOne({ _id: req.params.id, empresaId: req.empresaId });
+    if (!tarea) return res.status(404).json({ mensaje: 'Tarea no encontrada' });
+    res.json(tarea);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener tarea', error: error.message });
+  }
+};
+
+const crearTarea = async (req, res) => {
+  try {
+    const tarea = new Tarea({ ...req.body, empresaId: req.empresaId });
+    await tarea.save();
+    res.status(201).json(tarea);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear tarea', error: error.message });
+  }
+};
+
+const actualizarTarea = async (req, res) => {
+  try {
+    const tarea = await Tarea.findOneAndUpdate(
+      { _id: req.params.id, empresaId: req.empresaId },
+      req.body,
+      { new: true, runValidators: true }
+    );
+    if (!tarea) return res.status(404).json({ mensaje: 'Tarea no encontrada' });
+    res.json(tarea);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar tarea', error: error.message });
+  }
+};
+
+const eliminarTarea = async (req, res) => {
+  try {
+    const tarea = await Tarea.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
+    if (!tarea) return res.status(404).json({ mensaje: 'Tarea no encontrada' });
+    res.json({ mensaje: 'Tarea eliminada' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar tarea', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerTareas,
+  obtenerTarea,
+  crearTarea,
+  actualizarTarea,
+  eliminarTarea
+};

--- a/backend/models/OrdenProduccion.js
+++ b/backend/models/OrdenProduccion.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const etapaSchema = new mongoose.Schema({
+  nombre: String,
+  estado: { type: String, enum: ['pendiente', 'en_progreso', 'completada'], default: 'pendiente' },
+  responsable: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  fechaInicio: Date,
+  fechaFin: Date
+});
+
+const ordenProduccionSchema = new mongoose.Schema({
+  producto: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto', required: true },
+  cantidad: { type: Number, required: true },
+  etapas: [etapaSchema],
+  ventaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Venta' },
+  empresaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Empresa', required: true },
+  estadoGeneral: String,
+  observaciones: String
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('OrdenProduccion', ordenProduccionSchema);

--- a/backend/models/Tarea.js
+++ b/backend/models/Tarea.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+const comentarioSchema = new mongoose.Schema({
+  texto: String,
+  autor: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  fecha: { type: Date, default: Date.now }
+});
+
+const tareaSchema = new mongoose.Schema({
+  titulo: { type: String, required: true },
+  descripcion: String,
+  asignadoA: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  estado: {
+    type: String,
+    enum: ['pendiente', 'en_progreso', 'completada', 'cancelada'],
+    default: 'pendiente'
+  },
+  prioridad: {
+    type: String,
+    enum: ['alta', 'media', 'baja'],
+    default: 'media'
+  },
+  clienteId: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente' },
+  productoId: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto' },
+  fechaInicio: Date,
+  fechaVencimiento: Date,
+  empresaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Empresa', required: true },
+  comentarios: [comentarioSchema]
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Tarea', tareaSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -24,7 +24,7 @@ const userSchema = new mongoose.Schema({
   },
   rol: {
     type: String,
-    enum: ['admin', 'ventas', 'compras', 'inventario', 'rrhh', 'produccion'],
+    enum: ['admin', 'ventas', 'compras', 'inventario', 'rrhh', 'produccion', 'soporte'],
     default: 'ventas'
   }
 }, {

--- a/backend/routes/ordenes.js
+++ b/backend/routes/ordenes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerOrdenes,
+  obtenerOrden,
+  crearOrden,
+  actualizarOrden,
+  eliminarOrden
+} = require('../controllers/ordenProduccionController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerOrdenes);
+router.get('/:id', verificarToken, obtenerOrden);
+router.post('/', verificarToken, permitirRoles('admin', 'produccion'), crearOrden);
+router.put('/:id', verificarToken, permitirRoles('admin', 'produccion'), actualizarOrden);
+router.delete('/:id', verificarToken, permitirRoles('admin', 'produccion'), eliminarOrden);
+
+module.exports = router;

--- a/backend/routes/tareas.js
+++ b/backend/routes/tareas.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerTareas,
+  obtenerTarea,
+  crearTarea,
+  actualizarTarea,
+  eliminarTarea
+} = require('../controllers/tareaController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerTareas);
+router.get('/:id', verificarToken, obtenerTarea);
+router.post('/', verificarToken, permitirRoles('admin', 'produccion', 'soporte'), crearTarea);
+router.put('/:id', verificarToken, permitirRoles('admin', 'produccion', 'soporte'), actualizarTarea);
+router.delete('/:id', verificarToken, permitirRoles('admin', 'produccion'), eliminarTarea);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- introduce `Tarea` model with comments and tenant filtering
- add `OrdenProduccion` model with production stages
- implement CRUD controllers for tasks and production orders
- expose `/api/tareas` and `/api/ordenes` routes with JWT and role checks
- register routes in Express app and add `soporte` role
- document new role and modules in backend README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688482e0d90c8333b30cd38f1f77caf8