### PR TITLE
Add tasks and production modules

### DIFF
--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -163,6 +163,7 @@ JWT_SECRET=supersecreto123
 - `inventario`
 - `rrhh`
 - `produccion`
+- `soporte`
 
 ---
 
@@ -177,6 +178,7 @@ JWT_SECRET=supersecreto123
 - Ventas creadas a partir de presupuestos aceptados
 - Pagos registrados
 - Inventario con movimientos de stock y reportes
+- Tareas y órdenes de producción
 ---
 
 ## 🧑‍💻 Autor

--- a/backend/app.js
+++ b/backend/app.js
@@ -61,6 +61,12 @@ app.use('/api/pagos', pagosRoutes);
 const movimientosRoutes = require('./routes/movimientos');
 app.use('/api/movimientos', movimientosRoutes);
 
+const tareasRoutes = require('./routes/tareas');
+app.use('/api/tareas', tareasRoutes);
+
+const ordenesRoutes = require('./routes/ordenes');
+app.use('/api/ordenes', ordenesRoutes);
+
 
 
 module.exports = app;

--- a/backend/controllers/ordenProduccionController.js
+++ b/backend/controllers/ordenProduccionController.js
@@ -1,0 +1,74 @@
+const OrdenProduccion = require('../models/OrdenProduccion');
+
+const calcularEstado = (etapas = []) => {
+  if (!etapas.length) return 'pendiente';
+  if (etapas.every(e => e.estado === 'completada')) return 'completada';
+  if (etapas.some(e => e.estado === 'en_progreso')) return 'en_progreso';
+  return 'pendiente';
+};
+
+const obtenerOrdenes = async (req, res) => {
+  try {
+    const ordenes = await OrdenProduccion.find({ empresaId: req.empresaId }).populate('producto');
+    res.json(ordenes);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener órdenes', error: error.message });
+  }
+};
+
+const obtenerOrden = async (req, res) => {
+  try {
+    const orden = await OrdenProduccion.findOne({ _id: req.params.id, empresaId: req.empresaId }).populate('producto');
+    if (!orden) return res.status(404).json({ mensaje: 'Orden no encontrada' });
+    res.json(orden);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener orden', error: error.message });
+  }
+};
+
+const crearOrden = async (req, res) => {
+  try {
+    const orden = new OrdenProduccion({ ...req.body, empresaId: req.empresaId });
+    orden.estadoGeneral = calcularEstado(orden.etapas);
+    await orden.save();
+    res.status(201).json(orden);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear orden', error: error.message });
+  }
+};
+
+const actualizarOrden = async (req, res) => {
+  try {
+    const data = { ...req.body };
+    if (data.etapas) {
+      data.estadoGeneral = calcularEstado(data.etapas);
+    }
+    const orden = await OrdenProduccion.findOneAndUpdate(
+      { _id: req.params.id, empresaId: req.empresaId },
+      data,
+      { new: true, runValidators: true }
+    );
+    if (!orden) return res.status(404).json({ mensaje: 'Orden no encontrada' });
+    res.json(orden);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar orden', error: error.message });
+  }
+};
+
+const eliminarOrden = async (req, res) => {
+  try {
+    const orden = await OrdenProduccion.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
+    if (!orden) return res.status(404).json({ mensaje: 'Orden no encontrada' });
+    res.json({ mensaje: 'Orden eliminada' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar orden', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerOrdenes,
+  obtenerOrden,
+  crearOrden,
+  actualizarOrden,
+  eliminarOrden
+};

--- a/backend/controllers/tareaController.js
+++ b/backend/controllers/tareaController.js
@@ -1,0 +1,62 @@
+const Tarea = require('../models/Tarea');
+
+const obtenerTareas = async (req, res) => {
+  try {
+    const tareas = await Tarea.find({ empresaId: req.empresaId });
+    res.json(tareas);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener tareas', error: error.message });
+  }
+};
+
+const obtenerTarea = async (req, res) => {
+  try {
+    const tarea = await Tarea.findOne({ _id: req.params.id, empresaId: req.empresaId });
+    if (!tarea) return res.status(404).json({ mensaje: 'Tarea no encontrada' });
+    res.json(tarea);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener tarea', error: error.message });
+  }
+};
+
+const crearTarea = async (req, res) => {
+  try {
+    const tarea = new Tarea({ ...req.body, empresaId: req.empresaId });
+    await tarea.save();
+    res.status(201).json(tarea);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al crear tarea', error: error.message });
+  }
+};
+
+const actualizarTarea = async (req, res) => {
+  try {
+    const tarea = await Tarea.findOneAndUpdate(
+      { _id: req.params.id, empresaId: req.empresaId },
+      req.body,
+      { new: true, runValidators: true }
+    );
+    if (!tarea) return res.status(404).json({ mensaje: 'Tarea no encontrada' });
+    res.json(tarea);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al actualizar tarea', error: error.message });
+  }
+};
+
+const eliminarTarea = async (req, res) => {
+  try {
+    const tarea = await Tarea.findOneAndDelete({ _id: req.params.id, empresaId: req.empresaId });
+    if (!tarea) return res.status(404).json({ mensaje: 'Tarea no encontrada' });
+    res.json({ mensaje: 'Tarea eliminada' });
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al eliminar tarea', error: error.message });
+  }
+};
+
+module.exports = {
+  obtenerTareas,
+  obtenerTarea,
+  crearTarea,
+  actualizarTarea,
+  eliminarTarea
+};

--- a/backend/models/OrdenProduccion.js
+++ b/backend/models/OrdenProduccion.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const etapaSchema = new mongoose.Schema({
+  nombre: String,
+  estado: { type: String, enum: ['pendiente', 'en_progreso', 'completada'], default: 'pendiente' },
+  responsable: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  fechaInicio: Date,
+  fechaFin: Date
+});
+
+const ordenProduccionSchema = new mongoose.Schema({
+  producto: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto', required: true },
+  cantidad: { type: Number, required: true },
+  etapas: [etapaSchema],
+  ventaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Venta' },
+  empresaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Empresa', required: true },
+  estadoGeneral: String,
+  observaciones: String
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('OrdenProduccion', ordenProduccionSchema);

--- a/backend/models/Tarea.js
+++ b/backend/models/Tarea.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+const comentarioSchema = new mongoose.Schema({
+  texto: String,
+  autor: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  fecha: { type: Date, default: Date.now }
+});
+
+const tareaSchema = new mongoose.Schema({
+  titulo: { type: String, required: true },
+  descripcion: String,
+  asignadoA: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  estado: {
+    type: String,
+    enum: ['pendiente', 'en_progreso', 'completada', 'cancelada'],
+    default: 'pendiente'
+  },
+  prioridad: {
+    type: String,
+    enum: ['alta', 'media', 'baja'],
+    default: 'media'
+  },
+  clienteId: { type: mongoose.Schema.Types.ObjectId, ref: 'Cliente' },
+  productoId: { type: mongoose.Schema.Types.ObjectId, ref: 'Producto' },
+  fechaInicio: Date,
+  fechaVencimiento: Date,
+  empresaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Empresa', required: true },
+  comentarios: [comentarioSchema]
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Tarea', tareaSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -24,7 +24,7 @@ const userSchema = new mongoose.Schema({
   },
   rol: {
     type: String,
-    enum: ['admin', 'ventas', 'compras', 'inventario', 'rrhh', 'produccion'],
+    enum: ['admin', 'ventas', 'compras', 'inventario', 'rrhh', 'produccion', 'soporte'],
     default: 'ventas'
   }
 }, {

--- a/backend/routes/ordenes.js
+++ b/backend/routes/ordenes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerOrdenes,
+  obtenerOrden,
+  crearOrden,
+  actualizarOrden,
+  eliminarOrden
+} = require('../controllers/ordenProduccionController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerOrdenes);
+router.get('/:id', verificarToken, obtenerOrden);
+router.post('/', verificarToken, permitirRoles('admin', 'produccion'), crearOrden);
+router.put('/:id', verificarToken, permitirRoles('admin', 'produccion'), actualizarOrden);
+router.delete('/:id', verificarToken, permitirRoles('admin', 'produccion'), eliminarOrden);
+
+module.exports = router;

--- a/backend/routes/tareas.js
+++ b/backend/routes/tareas.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  obtenerTareas,
+  obtenerTarea,
+  crearTarea,
+  actualizarTarea,
+  eliminarTarea
+} = require('../controllers/tareaController');
+
+const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
+
+router.get('/', verificarToken, obtenerTareas);
+router.get('/:id', verificarToken, obtenerTarea);
+router.post('/', verificarToken, permitirRoles('admin', 'produccion', 'soporte'), crearTarea);
+router.put('/:id', verificarToken, permitirRoles('admin', 'produccion', 'soporte'), actualizarTarea);
+router.delete('/:id', verificarToken, permitirRoles('admin', 'produccion'), eliminarTarea);
+
+module.exports = router;

--- a/backend/tests/ordenProduccionController.test.js
+++ b/backend/tests/ordenProduccionController.test.js
@@ -1,0 +1,16 @@
+const ordenController = require('../controllers/ordenProduccionController');
+const Orden = require('../models/OrdenProduccion');
+
+jest.mock('../models/OrdenProduccion');
+
+describe('eliminarOrden', () => {
+  test('solo elimina dentro de la empresa', async () => {
+    const req = { params: { id: '2' }, empresaId: 'empresa1' };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    Orden.findOneAndDelete.mockResolvedValue({});
+
+    await ordenController.eliminarOrden(req, res);
+
+    expect(Orden.findOneAndDelete).toHaveBeenCalledWith({ _id: '2', empresaId: 'empresa1' });
+  });
+});

--- a/backend/tests/tareaController.test.js
+++ b/backend/tests/tareaController.test.js
@@ -1,0 +1,21 @@
+const tareaController = require('../controllers/tareaController');
+const Tarea = require('../models/Tarea');
+
+jest.mock('../models/Tarea');
+
+describe('actualizarTarea', () => {
+  test('usa empresaId para buscar la tarea', async () => {
+    const req = { params: { id: '1' }, empresaId: 'empresa1', body: { titulo: 'n' } };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    const tareaMock = { _id: '1', empresaId: 'empresa1' };
+    Tarea.findOneAndUpdate.mockResolvedValue(tareaMock);
+
+    await tareaController.actualizarTarea(req, res);
+
+    expect(Tarea.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: '1', empresaId: 'empresa1' },
+      req.body,
+      { new: true, runValidators: true }
+    );
+  });
+});

--- a/frontend/src/components/FormularioOrden.jsx
+++ b/frontend/src/components/FormularioOrden.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+
+function FormularioOrden({ ordenInicial = {}, onSubmit }) {
+  const [orden, setOrden] = useState({
+    producto: '',
+    cantidad: 1,
+    observaciones: '',
+    ...ordenInicial
+  });
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setOrden(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit(orden);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded shadow">
+      <div>
+        <label className="block font-semibold mb-1">Producto</label>
+        <input
+          type="text"
+          name="producto"
+          value={orden.producto}
+          onChange={handleChange}
+          required
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Cantidad</label>
+        <input
+          type="number"
+          name="cantidad"
+          value={orden.cantidad}
+          onChange={handleChange}
+          min="1"
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Observaciones</label>
+        <textarea
+          name="observaciones"
+          value={orden.observaciones}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <button className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+        Guardar Orden
+      </button>
+    </form>
+  );
+}
+
+export default FormularioOrden;

--- a/frontend/src/components/FormularioTarea.jsx
+++ b/frontend/src/components/FormularioTarea.jsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+
+function FormularioTarea({ tareaInicial = {}, onSubmit }) {
+  const [tarea, setTarea] = useState({
+    titulo: '',
+    descripcion: '',
+    prioridad: 'media',
+    fechaVencimiento: '',
+    ...tareaInicial
+  });
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setTarea(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit(tarea);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded shadow">
+      <div>
+        <label className="block font-semibold mb-1">Título</label>
+        <input
+          type="text"
+          name="titulo"
+          value={tarea.titulo}
+          onChange={handleChange}
+          required
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Descripción</label>
+        <textarea
+          name="descripcion"
+          value={tarea.descripcion}
+          onChange={handleChange}
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block font-semibold mb-1">Prioridad</label>
+          <select
+            name="prioridad"
+            value={tarea.prioridad}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+          >
+            <option value="alta">Alta</option>
+            <option value="media">Media</option>
+            <option value="baja">Baja</option>
+          </select>
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">Vencimiento</label>
+          <input
+            type="date"
+            name="fechaVencimiento"
+            value={tarea.fechaVencimiento ? tarea.fechaVencimiento.substring(0,10) : ''}
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+      </div>
+      <button className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+        Guardar Tarea
+      </button>
+    </form>
+  );
+}
+
+export default FormularioTarea;

--- a/frontend/src/layout/DashboardLayout.jsx
+++ b/frontend/src/layout/DashboardLayout.jsx
@@ -31,6 +31,10 @@ function DashboardLayout({ children }) {
           <Link to="/dashboard/facturas" className="hover:text-blue-300">Facturas</Link>
           <Link to="/dashboard/presupuestos" className="hover:text-blue-300">Presupuestos</Link>
           <Link to="/dashboard/proveedores" className="hover:text-blue-300">Proveedores</Link>
+          <Link to="/dashboard/tareas" className="hover:text-blue-300">Tareas</Link>
+          {(usuario?.rol === 'admin' || usuario?.rol === 'produccion') && (
+            <Link to="/dashboard/produccion" className="hover:text-blue-300">Producción</Link>
+          )}
         </nav>
 
         <button
@@ -59,6 +63,10 @@ function DashboardLayout({ children }) {
           <Link to="/dashboard/ventas" className="hover:text-blue-300" onClick={toggleSidebar}>Ventas</Link>
           <Link to="/dashboard/proveedores" className="hover:text-blue-300" onClick={toggleSidebar}>Proveedores</Link>
           <Link to="/dashboard/presupuestos" className="hover:text-blue-300" onClick={toggleSidebar}>Presupuestos</Link>
+          <Link to="/dashboard/tareas" className="hover:text-blue-300" onClick={toggleSidebar}>Tareas</Link>
+          {(usuario?.rol === 'admin' || usuario?.rol === 'produccion') && (
+            <Link to="/dashboard/produccion" className="hover:text-blue-300" onClick={toggleSidebar}>Producción</Link>
+          )}
         </nav>
         <button
           onClick={() => { logout(); setSidebarOpen(false); }}

--- a/frontend/src/pages/produccion/DetalleOrden.jsx
+++ b/frontend/src/pages/produccion/DetalleOrden.jsx
@@ -1,0 +1,84 @@
+import { useContext, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+
+function DetalleOrden() {
+  const { id } = useParams();
+  const { token } = useContext(AuthContext);
+  const [orden, setOrden] = useState(null);
+  const navigate = useNavigate();
+
+  const obtenerOrden = async () => {
+    try {
+      const { data } = await clienteAxios.get(`/ordenes/${id}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setOrden(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => { obtenerOrden(); }, [id, token]);
+
+  const handleEtapaChange = (index, field, value) => {
+    setOrden(prev => {
+      const etapas = [...prev.etapas];
+      etapas[index] = { ...etapas[index], [field]: value };
+      return { ...prev, etapas };
+    });
+  };
+
+  const guardarCambios = async () => {
+    try {
+      await clienteAxios.put(`/ordenes/${id}`, orden, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      navigate('/dashboard/produccion');
+    } catch (error) {
+      alert('Error al guardar');
+    }
+  };
+
+  if (!orden) return <p>Cargando...</p>;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">Orden de Producción</h2>
+      <p>Producto: {orden.producto?.nombre || orden.producto}</p>
+      <p>Cantidad: {orden.cantidad}</p>
+
+      <h3 className="font-semibold">Etapas</h3>
+      <div className="space-y-2">
+        {orden.etapas.map((etapa, idx) => (
+          <div key={idx} className="bg-gray-100 p-2 rounded space-y-1">
+            <input
+              type="text"
+              value={etapa.nombre}
+              onChange={e => handleEtapaChange(idx, 'nombre', e.target.value)}
+              className="w-full p-1 border rounded"
+              placeholder="Nombre"
+            />
+            <select
+              value={etapa.estado}
+              onChange={e => handleEtapaChange(idx, 'estado', e.target.value)}
+              className="w-full p-1 border rounded"
+            >
+              <option value="pendiente">Pendiente</option>
+              <option value="en_progreso">En progreso</option>
+              <option value="completada">Completada</option>
+            </select>
+          </div>
+        ))}
+        {orden.etapas.length === 0 && <p className="text-sm text-gray-500">Sin etapas</p>}
+      </div>
+
+      <button onClick={guardarCambios} className="bg-blue-600 text-white px-4 py-2 rounded">
+        Guardar Cambios
+      </button>
+    </div>
+  );
+}
+
+export default DetalleOrden;

--- a/frontend/src/pages/produccion/NuevaOrden.jsx
+++ b/frontend/src/pages/produccion/NuevaOrden.jsx
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import FormularioOrden from '../../components/FormularioOrden';
+
+function NuevaOrden() {
+  const { token } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const crearOrden = async datos => {
+    try {
+      await clienteAxios.post('/ordenes', datos, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      navigate('/dashboard/produccion');
+    } catch (error) {
+      alert('Error al crear orden');
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Nueva Orden</h2>
+      <FormularioOrden onSubmit={crearOrden} />
+    </div>
+  );
+}
+
+export default NuevaOrden;

--- a/frontend/src/pages/produccion/Ordenes.jsx
+++ b/frontend/src/pages/produccion/Ordenes.jsx
@@ -1,0 +1,53 @@
+import { useContext, useEffect, useState } from 'react';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+import { Link } from 'react-router-dom';
+
+function Ordenes() {
+  const { token } = useContext(AuthContext);
+  const [ordenes, setOrdenes] = useState([]);
+
+  const obtenerOrdenes = async () => {
+    try {
+      const { data } = await clienteAxios.get('/ordenes', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setOrdenes(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => { obtenerOrdenes(); }, [token]);
+
+  const progreso = etapas => {
+    if (!etapas.length) return 0;
+    const completadas = etapas.filter(e => e.estado === 'completada').length;
+    return Math.round((completadas / etapas.length) * 100);
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold">Órdenes de Producción</h2>
+        <Link to="/dashboard/produccion/nueva" className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
+          + Nueva Orden
+        </Link>
+      </div>
+      <div className="space-y-4">
+        {ordenes.map(orden => (
+          <Link key={orden._id} to={`/dashboard/produccion/${orden._id}`} className="block bg-white p-4 rounded shadow hover:bg-gray-50">
+            <p className="font-semibold">Producto: {orden.producto?.nombre || orden.producto}</p>
+            <p>Cantidad: {orden.cantidad}</p>
+            <div className="h-2 bg-gray-200 rounded mt-2">
+              <div className="h-2 bg-blue-600 rounded" style={{ width: `${progreso(orden.etapas)}%` }} />
+            </div>
+          </Link>
+        ))}
+        {ordenes.length === 0 && <p className="text-gray-500">No hay órdenes registradas</p>}
+      </div>
+    </div>
+  );
+}
+
+export default Ordenes;

--- a/frontend/src/pages/tareas/DetalleTarea.jsx
+++ b/frontend/src/pages/tareas/DetalleTarea.jsx
@@ -1,0 +1,95 @@
+import { useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+
+function DetalleTarea() {
+  const { id } = useParams();
+  const { token } = useContext(AuthContext);
+  const [tarea, setTarea] = useState(null);
+  const [comentario, setComentario] = useState('');
+
+  const obtenerTarea = async () => {
+    try {
+      const { data } = await clienteAxios.get(`/tareas/${id}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setTarea(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => { obtenerTarea(); }, [id, token]);
+
+  const agregarComentario = async () => {
+    const nueva = { ...tarea, comentarios: [...tarea.comentarios, { texto: comentario }] };
+    try {
+      await clienteAxios.put(`/tareas/${id}`, nueva, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setComentario('');
+      obtenerTarea();
+    } catch (error) {
+      alert('Error al comentar');
+    }
+  };
+
+  const cambiarEstado = async e => {
+    const nueva = { ...tarea, estado: e.target.value };
+    try {
+      await clienteAxios.put(`/tareas/${id}`, nueva, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      obtenerTarea();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  if (!tarea) return <p>Cargando...</p>;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">{tarea.titulo}</h2>
+      <p>{tarea.descripcion}</p>
+      <div>
+        <label className="font-semibold mr-2">Estado:</label>
+        <select value={tarea.estado} onChange={cambiarEstado} className="p-2 border rounded">
+          <option value="pendiente">Pendiente</option>
+          <option value="en_progreso">En progreso</option>
+          <option value="completada">Completada</option>
+          <option value="cancelada">Cancelada</option>
+        </select>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Comentarios</h3>
+        <ul className="space-y-1 mb-2">
+          {tarea.comentarios.map((c, idx) => (
+            <li key={idx} className="bg-gray-100 p-2 rounded">{c.texto}</li>
+          ))}
+          {tarea.comentarios.length === 0 && (
+            <li className="text-sm text-gray-500">Sin comentarios</li>
+          )}
+        </ul>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={comentario}
+            onChange={e => setComentario(e.target.value)}
+            className="flex-1 p-2 border rounded"
+          />
+          <button
+            onClick={agregarComentario}
+            className="bg-blue-600 text-white px-3 rounded"
+          >
+            Añadir
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DetalleTarea;

--- a/frontend/src/pages/tareas/Tareas.jsx
+++ b/frontend/src/pages/tareas/Tareas.jsx
@@ -1,0 +1,83 @@
+import { useContext, useEffect, useState } from 'react';
+import clienteAxios from '../../api/clienteAxios';
+import { AuthContext } from '../../context/AuthContext';
+import FormularioTarea from '../../components/FormularioTarea';
+import { Link } from 'react-router-dom';
+
+const estados = ['pendiente', 'en_progreso', 'completada', 'cancelada'];
+
+function Tareas() {
+  const { token } = useContext(AuthContext);
+  const [tareas, setTareas] = useState([]);
+  const [mostrarFormulario, setMostrarFormulario] = useState(false);
+
+  const obtenerTareas = async () => {
+    try {
+      const { data } = await clienteAxios.get('/tareas', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setTareas(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    obtenerTareas();
+  }, [token]);
+
+  const crearTarea = async datos => {
+    try {
+      await clienteAxios.post('/tareas', datos, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setMostrarFormulario(false);
+      obtenerTareas();
+    } catch (error) {
+      alert('Error al crear tarea');
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold">Tareas</h2>
+        <button
+          onClick={() => setMostrarFormulario(!mostrarFormulario)}
+          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+        >
+          + Nueva Tarea
+        </button>
+      </div>
+
+      {mostrarFormulario && (
+        <FormularioTarea onSubmit={crearTarea} />
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mt-6">
+        {estados.map(estado => (
+          <div key={estado} className="bg-gray-100 rounded p-2">
+            <h3 className="text-center font-semibold capitalize mb-2">{estado.replace('_', ' ')}</h3>
+            <div className="space-y-2">
+              {tareas.filter(t => t.estado === estado).map(tarea => (
+                <Link
+                  key={tarea._id}
+                  to={`/dashboard/tareas/${tarea._id}`}
+                  className="block bg-white p-2 rounded shadow hover:bg-gray-50"
+                >
+                  <p className="font-medium">{tarea.titulo}</p>
+                  <p className="text-sm text-gray-500">Prioridad: {tarea.prioridad}</p>
+                </Link>
+              ))}
+              {tareas.filter(t => t.estado === estado).length === 0 && (
+                <p className="text-sm text-gray-400 text-center">Sin tareas</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Tareas;

--- a/frontend/src/routes/AppRoute.jsx
+++ b/frontend/src/routes/AppRoute.jsx
@@ -37,6 +37,11 @@ import DetalleVenta from '../pages/ventas/DetalleVenta';
 import HistorialMovimientos from '../pages/inventario/HistorialMovimientos';
 import NuevaEntrada from '../pages/inventario/NuevaEntrada';
 import NuevaSalida from '../pages/inventario/NuevaSalida';
+import Tareas from '../pages/tareas/Tareas';
+import DetalleTarea from '../pages/tareas/DetalleTarea';
+import Ordenes from '../pages/produccion/Ordenes';
+import NuevaOrden from '../pages/produccion/NuevaOrden';
+import DetalleOrden from '../pages/produccion/DetalleOrden';
 
 function AppRoutes() {
   return (
@@ -299,6 +304,66 @@ function AppRoutes() {
             <DashboardLayout>
               <ImportarProductos />
             </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+
+      {/* Tareas */}
+      <Route
+        path="/dashboard/tareas"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <Tareas />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/tareas/:id"
+        element={
+          <PrivateRoute>
+            <DashboardLayout>
+              <DetalleTarea />
+            </DashboardLayout>
+          </PrivateRoute>
+        }
+      />
+
+      {/* Produccion */}
+      <Route
+        path="/dashboard/produccion"
+        element={
+          <PrivateRoute>
+            <RolProtectedRoute rolesPermitidos={['admin', 'produccion']}>
+              <DashboardLayout>
+                <Ordenes />
+              </DashboardLayout>
+            </RolProtectedRoute>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/produccion/nueva"
+        element={
+          <PrivateRoute>
+            <RolProtectedRoute rolesPermitidos={['admin', 'produccion']}>
+              <DashboardLayout>
+                <NuevaOrden />
+              </DashboardLayout>
+            </RolProtectedRoute>
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/dashboard/produccion/:id"
+        element={
+          <PrivateRoute>
+            <RolProtectedRoute rolesPermitidos={['admin', 'produccion']}>
+              <DashboardLayout>
+                <DetalleOrden />
+              </DashboardLayout>
+            </RolProtectedRoute>
           </PrivateRoute>
         }
       />


### PR DESCRIPTION
## Summary
- implement Kanban board and task detail views
- add production order pages with editable stages
- introduce forms for tasks and orders
- update dashboard navigation and routes
- add unit tests for tenant filters

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688482e0d90c8333b30cd38f1f77caf8