### PR TITLE
Add daily stock alert automation

### DIFF
--- a/backend/jobs/stockAlertJob.js
+++ b/backend/jobs/stockAlertJob.js
@@ -1,0 +1,28 @@
+const cron = require('node-cron');
+const {
+  encontrarProductosCriticos,
+  obtenerEmailAdmin,
+  enviarAlertaStock
+} = require('../services/stockAlertService');
+
+// Ejecuta la revisión y envío de alertas
+const ejecutarRevisionStock = async () => {
+  const porEmpresa = await encontrarProductosCriticos();
+  for (const [empresaId, productos] of Object.entries(porEmpresa)) {
+    const email = await obtenerEmailAdmin(empresaId);
+    if (email && productos.length) {
+      await enviarAlertaStock(email, productos);
+    }
+  }
+};
+
+// Programa la tarea diaria a las 8am
+const iniciarAlertaStockJob = () => {
+  cron.schedule('0 8 * * *', () => {
+    ejecutarRevisionStock().catch(err =>
+      console.error('Error en alerta de stock:', err)
+    );
+  });
+};
+
+module.exports = iniciarAlertaStockJob;

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,9 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.16.3"
+    "mongoose": "^8.16.3",
+    "nodemailer": "^6.9.13",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,3 +9,7 @@ const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {
   console.log(`Servidor corriendo en puerto ${PORT}`);
 });
+
+// Iniciar tarea programada de alertas de stock
+const iniciarAlertaStockJob = require('./jobs/stockAlertJob');
+iniciarAlertaStockJob();

--- a/backend/services/stockAlertService.js
+++ b/backend/services/stockAlertService.js
@@ -1,0 +1,52 @@
+const Producto = require('../models/Product');
+const User = require('../models/User');
+const nodemailer = require('nodemailer');
+
+// Devuelve un objeto { empresaId: [productos...] } con stock bajo
+const encontrarProductosCriticos = async () => {
+  const productos = await Producto.find({
+    $expr: { $lt: ['$stock', '$stockMinimo'] }
+  }).lean();
+
+  return productos.reduce((acc, prod) => {
+    const id = prod.empresaId.toString();
+    if (!acc[id]) acc[id] = [];
+    acc[id].push(prod);
+    return acc;
+  }, {});
+};
+
+// Obtiene el correo del usuario administrador de una empresa
+const obtenerEmailAdmin = async (empresaId) => {
+  const admin = await User.findOne({ empresaId, rol: 'admin' }).lean();
+  return admin ? admin.email : null;
+};
+
+// Envía un correo utilizando Nodemailer con los productos críticos
+const enviarAlertaStock = async (destinatario, productos) => {
+  if (!destinatario) return;
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+
+  const lista = productos.map(p => `${p.nombre} (stock: ${p.stock})`).join('\n');
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM,
+    to: destinatario,
+    subject: 'Alerta de stock bajo',
+    text: `Los siguientes productos están por debajo del stock mínimo:\n\n${lista}`
+  });
+};
+
+module.exports = {
+  encontrarProductosCriticos,
+  obtenerEmailAdmin,
+  enviarAlertaStock
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,9 @@
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.16.3"
+        "mongoose": "^8.16.3",
+        "node-cron": "^3.0.3",
+        "nodemailer": "^6.9.13"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -10375,6 +10377,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10388,6 +10402,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.10",
@@ -12664,6 +12687,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {


### PR DESCRIPTION
## Summary
- add service to search for products below minimum stock and notify admins via email
- schedule cron job at 8am with `node-cron`
- start job from server
- include `nodemailer` and `node-cron` dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886a650788c833383c198f4df93a56e