### PR TITLE
Add reusable notifications

### DIFF
--- a/frontend/src/components/Notification.jsx
+++ b/frontend/src/components/Notification.jsx
@@ -1,0 +1,43 @@
+// Notificación reutilizable con variantes y animación
+
+import { XMarkIcon, CheckCircleIcon, ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { motion } from 'framer-motion';
+import PropTypes from 'prop-types';
+
+const icons = {
+  success: CheckCircleIcon,
+  error: ExclamationTriangleIcon,
+  warning: ExclamationTriangleIcon,
+  info: InformationCircleIcon,
+};
+
+const styles = {
+  success: 'border-green-500 bg-green-100 text-green-700',
+  error: 'border-red-500 bg-red-100 text-red-700',
+  warning: 'border-yellow-500 bg-yellow-100 text-yellow-700',
+  info: 'border-blue-500 bg-blue-100 text-blue-700',
+};
+
+export default function Notification({ type = 'info', children, onClose }) {
+  const Icon = icons[type] || InformationCircleIcon;
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className={`flex items-start gap-2 border-l-4 p-4 rounded shadow ${styles[type]}`}
+    >
+      <Icon className="w-5 h-5 mt-0.5" />
+      <div className="text-sm flex-1">{children}</div>
+      <button onClick={onClose} aria-label="Cerrar" className="text-inherit">
+        <XMarkIcon className="w-4 h-4" />
+      </button>
+    </motion.div>
+  );
+}
+
+Notification.propTypes = {
+  type: PropTypes.oneOf(['success', 'error', 'warning', 'info']),
+  children: PropTypes.node.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/frontend/src/context/NotificationContext.jsx
+++ b/frontend/src/context/NotificationContext.jsx
@@ -1,0 +1,43 @@
+// Contexto global para mostrar notificaciones tipo toast
+
+import { createContext, useCallback, useContext, useState } from 'react';
+import PropTypes from 'prop-types';
+import Notification from '../components/Notification';
+import { AnimatePresence } from 'framer-motion';
+
+const NotificationContext = createContext();
+
+export const NotificationProvider = ({ children }) => {
+  const [notis, setNotis] = useState([]);
+
+  const showNotification = useCallback((type, message, duration = 4000) => {
+    const id = Date.now();
+    setNotis(n => [...n, { id, type, message }]);
+    setTimeout(() => {
+      setNotis(n => n.filter(not => not.id !== id));
+    }, duration);
+  }, []);
+
+  const remove = id => setNotis(n => n.filter(not => not.id !== id));
+
+  return (
+    <NotificationContext.Provider value={{ showNotification }}>
+      {children}
+      <div className="fixed top-5 right-5 space-y-2 z-50">
+        <AnimatePresence>
+          {notis.map(n => (
+            <Notification key={n.id} type={n.type} onClose={() => remove(n.id)}>
+              {n.message}
+            </Notification>
+          ))}
+        </AnimatePresence>
+      </div>
+    </NotificationContext.Provider>
+  );
+};
+
+NotificationProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useNotification = () => useContext(NotificationContext);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,15 +4,16 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 import { AuthProvider } from './context/AuthContext.jsx';
+import { NotificationProvider } from './context/NotificationContext.jsx';
 
 
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider>
-
-      <App />
-
-    </AuthProvider>
+    <NotificationProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </NotificationProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/SolicitarDemo.jsx
+++ b/frontend/src/pages/SolicitarDemo.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import axios from 'axios';
 import Header from '../layout/Header';
+import { useNotification } from '../context/NotificationContext';
 
 export default function SolicitarDemo() {
   const [formulario, setFormulario] = useState({
@@ -12,7 +13,7 @@ export default function SolicitarDemo() {
     emailUsuario: '',
     contraseña: ''
   });
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const [error, setError] = useState('');
 
   const handleChange = e => {
@@ -22,7 +23,6 @@ export default function SolicitarDemo() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    setMensaje('');
     setError('');
     try {
       await axios.post('http://localhost:5000/api/empresas', {
@@ -34,7 +34,7 @@ export default function SolicitarDemo() {
         emailUsuario: formulario.emailUsuario,
         contraseña: formulario.contraseña
       });
-      setMensaje('Empresa creada correctamente. Ya podés iniciar sesión.');
+      showNotification('success', 'Empresa creada correctamente. Ya podés iniciar sesión.');
       setFormulario({
         nombreEmpresa: '',
         plan: 'demo',
@@ -46,6 +46,7 @@ export default function SolicitarDemo() {
       });
     } catch (err) {
       setError(err.response?.data?.mensaje || 'Error al crear empresa');
+      showNotification('error', err.response?.data?.mensaje || 'Error al crear empresa');
     }
   };
 
@@ -54,7 +55,6 @@ export default function SolicitarDemo() {
       <Header />
       <div className="max-w-xl mx-auto my-10 p-6 bg-white shadow rounded">
         <h2 className="text-2xl font-bold mb-4 text-center">Solicitar Demo</h2>
-        {mensaje && <div className="bg-green-100 p-3 mb-4 text-green-800 rounded">{mensaje}</div>}
         {error && <div className="bg-red-100 p-3 mb-4 text-red-800 rounded">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>

--- a/frontend/src/pages/clientes/Clientes.jsx
+++ b/frontend/src/pages/clientes/Clientes.jsx
@@ -1,12 +1,14 @@
 // Listado de clientes obtenido desde /api/clientes.
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { Link } from 'react-router-dom';
 
 
 function Clientes() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [clientes, setClientes] = useState([]);
 
   useEffect(() => {
@@ -34,7 +36,7 @@ function Clientes() {
       setClientes(prev => prev.filter(c => c._id !== id));
     } catch (error) {
       console.error(error);
-      alert('Error al eliminar cliente');
+      showNotification('error', 'Error al eliminar cliente');
     }
   };
 

--- a/frontend/src/pages/clientes/EditarCliente.jsx
+++ b/frontend/src/pages/clientes/EditarCliente.jsx
@@ -3,10 +3,12 @@ import { useEffect, useState, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import FormularioCliente from '../../components/FormularioCliente';
 
 function EditarCliente() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const { id } = useParams();
   const navigate = useNavigate();
   const [cliente, setCliente] = useState(null);
@@ -20,7 +22,7 @@ function EditarCliente() {
         setCliente(data);
       } catch (error) {
         console.error(error);
-        alert('Error al cargar cliente');
+        showNotification('error', 'Error al cargar cliente');
       }
     };
     obtenerCliente();
@@ -34,7 +36,7 @@ function EditarCliente() {
       navigate('/dashboard/clientes');
     } catch (error) {
       console.error(error);
-      alert('Error al actualizar cliente');
+      showNotification('error', 'Error al actualizar cliente');
     }
   };
 

--- a/frontend/src/pages/clientes/NuevoCliente.jsx
+++ b/frontend/src/pages/clientes/NuevoCliente.jsx
@@ -4,9 +4,11 @@ import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 import { useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 
 function NuevoCliente() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const navigate = useNavigate();
 
   const crearCliente = async (datos) => {
@@ -17,7 +19,7 @@ function NuevoCliente() {
       navigate('/dashboard/clientes');
     } catch (error) {
       console.error(error);
-      alert('Error al crear cliente');
+      showNotification('error', 'Error al crear cliente');
     }
   };
 

--- a/frontend/src/pages/inventario/NuevaEntrada.jsx
+++ b/frontend/src/pages/inventario/NuevaEntrada.jsx
@@ -1,11 +1,13 @@
 import { useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 import FormularioMovimiento from '../../components/FormularioMovimiento';
 
 function NuevaEntrada() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const navigate = useNavigate();
   const [datos, setDatos] = useState({ productoId: '', cantidad: 1, motivo: '' });
 
@@ -18,7 +20,7 @@ function NuevaEntrada() {
       navigate('/dashboard/inventario');
     } catch (error) {
       console.error(error);
-      alert('Error al registrar entrada');
+      showNotification('error', 'Error al registrar entrada');
     }
   };
 

--- a/frontend/src/pages/inventario/NuevaSalida.jsx
+++ b/frontend/src/pages/inventario/NuevaSalida.jsx
@@ -1,11 +1,13 @@
 import { useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 import FormularioMovimiento from '../../components/FormularioMovimiento';
 
 function NuevaSalida() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const navigate = useNavigate();
   const [datos, setDatos] = useState({ productoId: '', cantidad: 1, motivo: '' });
 
@@ -18,7 +20,7 @@ function NuevaSalida() {
       navigate('/dashboard/inventario');
     } catch (error) {
       console.error(error);
-      alert('Error al registrar salida');
+      showNotification('error', 'Error al registrar salida');
     }
   };
 

--- a/frontend/src/pages/presupuestos/NuevoPresupuesto.jsx
+++ b/frontend/src/pages/presupuestos/NuevoPresupuesto.jsx
@@ -1,12 +1,14 @@
 // Formulario para crear un presupuesto.
 import { useContext, useState } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 import FormularioPresupuesto from '../../components/FormularioPresupuesto';
 
 function NuevoPresupuesto() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const navigate = useNavigate();
 
   const [datos, setDatos] = useState({
@@ -37,7 +39,7 @@ function NuevoPresupuesto() {
 
       navigate('/dashboard/presupuestos');
     } catch (error) {
-      alert('Error al crear presupuesto');
+      showNotification('error', 'Error al crear presupuesto');
       console.error(error);
     }
   };

--- a/frontend/src/pages/presupuestos/Presupuestos.jsx
+++ b/frontend/src/pages/presupuestos/Presupuestos.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { Link } from 'react-router-dom';
 
 function Presupuestos() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [presupuestos, setPresupuestos] = useState([]);
   const [presupuestoActivo, setPresupuestoActivo] = useState(null);
 
@@ -31,7 +33,7 @@ function Presupuestos() {
       setPresupuestos(prev => prev.filter(p => p._id !== id));
     } catch (error) {
       console.error(error);
-      alert('Error al eliminar presupuesto');
+      showNotification('error', 'Error al eliminar presupuesto');
     }
   };
 
@@ -44,7 +46,7 @@ function Presupuestos() {
         p._id === id ? { ...p, estado: 'aceptado' } : p
       ));
     } catch (err) {
-      alert('Error al aceptar presupuesto');
+      showNotification('error', 'Error al aceptar presupuesto');
     }
   };
 

--- a/frontend/src/pages/produccion/DetalleOrden.jsx
+++ b/frontend/src/pages/produccion/DetalleOrden.jsx
@@ -2,10 +2,12 @@ import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 
 function DetalleOrden() {
   const { id } = useParams();
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [orden, setOrden] = useState(null);
   const navigate = useNavigate();
 
@@ -37,7 +39,7 @@ function DetalleOrden() {
       });
       navigate('/dashboard/produccion');
     } catch (error) {
-      alert('Error al guardar');
+      showNotification('error', 'Error al guardar');
     }
   };
 

--- a/frontend/src/pages/produccion/NuevaOrden.jsx
+++ b/frontend/src/pages/produccion/NuevaOrden.jsx
@@ -1,11 +1,13 @@
 import { useContext } from 'react';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import { useNavigate } from 'react-router-dom';
 import FormularioOrden from '../../components/FormularioOrden';
 
 function NuevaOrden() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const navigate = useNavigate();
 
   const crearOrden = async datos => {
@@ -15,7 +17,7 @@ function NuevaOrden() {
       });
       navigate('/dashboard/produccion');
     } catch (error) {
-      alert('Error al crear orden');
+      showNotification('error', 'Error al crear orden');
     }
   };
 

--- a/frontend/src/pages/productos/EditarProducto.jsx
+++ b/frontend/src/pages/productos/EditarProducto.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import FormularioProducto from '../../components/FormularioProducto';
 
 function EditarProducto() {
@@ -20,7 +21,7 @@ function EditarProducto() {
     activo: true
   });
 
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -42,24 +43,23 @@ function EditarProducto() {
   const handleSubmit = async e => {
     e.preventDefault();
     setError('');
-    setMensaje('');
 
     try {
       await clienteAxios.put(`/productos/${id}`, formulario, {
         headers: { Authorization: `Bearer ${token}` }
       });
-      setMensaje('Producto actualizado ✅');
+      showNotification('success', 'Producto actualizado ✅');
       setTimeout(() => navigate('/dashboard/productos'), 1500);
     } catch (error) {
       console.error(error);
       setError('Error al actualizar');
+      showNotification('error', 'Error al actualizar');
     }
   };
 
   return (
     <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
       <h2 className="text-2xl font-bold mb-4">Editar Producto</h2>
-      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
       {error && <p className="text-red-600 mb-2">{error}</p>}
       <FormularioProducto
         formulario={formulario}

--- a/frontend/src/pages/productos/NuevoProducto.jsx
+++ b/frontend/src/pages/productos/NuevoProducto.jsx
@@ -1,6 +1,7 @@
 // Formulario para crear un producto.
 import { useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 import FormularioProducto from '../../components/FormularioProducto';
@@ -19,14 +20,13 @@ function NuevoProducto() {
     activo: true
   });
 
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const [error, setError] = useState('');
 
 
   const handleSubmit = async e => {
     e.preventDefault();
     setError('');
-    setMensaje('');
 
     try {
       await clienteAxios.post('/productos', formulario, {
@@ -34,11 +34,12 @@ function NuevoProducto() {
           Authorization: `Bearer ${token}`
         }
       });
-      setMensaje('Producto creado correctamente');
-      setTimeout(() => navigate('/dashboard/productos'), 2000);
+      showNotification('success', 'Producto creado correctamente');
+      setTimeout(() => navigate('/dashboard/productos'), 1500);
     } catch (error) {
       console.error(error);
       setError(error.response?.data?.mensaje || 'Error al crear producto');
+      showNotification('error', error.response?.data?.mensaje || 'Error al crear producto');
     }
   };
 
@@ -46,7 +47,6 @@ function NuevoProducto() {
     <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
       <h2 className="text-2xl font-bold mb-4">Crear nuevo producto</h2>
 
-      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
       {error && <p className="text-red-600 mb-2">{error}</p>}
 
       <FormularioProducto

--- a/frontend/src/pages/productos/Productos.jsx
+++ b/frontend/src/pages/productos/Productos.jsx
@@ -1,12 +1,14 @@
 // Listado de productos consultado en /api/productos.
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { Link } from 'react-router-dom';
 import FiltrosProductos from './FiltrosProductos';
 
 function Productos() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [productos, setProductos] = useState([]);
   const [filtros, setFiltros] = useState({
     disponibilidad: '',
@@ -89,7 +91,7 @@ function Productos() {
       setProductos(prev => prev.filter(p => p._id !== id));
     } catch (error) {
       console.error(error);
-      alert('Error al eliminar producto');
+      showNotification('error', 'Error al eliminar producto');
     }
   };
 

--- a/frontend/src/pages/proveedores/EditarProveedores.jsx
+++ b/frontend/src/pages/proveedores/EditarProveedores.jsx
@@ -3,10 +3,12 @@ import { useEffect, useState, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import FormularioProveedor from '../../components/FormularioProveedor';
 
 function EditarProveedor() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const { id } = useParams();
   const navigate = useNavigate();
   const [proveedor, setProveedor] = useState(null);
@@ -20,7 +22,7 @@ function EditarProveedor() {
         setProveedor(data);
       } catch (error) {
         console.error(error);
-        alert('Error al cargar proveedor');
+        showNotification('error', 'Error al cargar proveedor');
       }
     };
     obtenerProveedor();
@@ -34,7 +36,7 @@ function EditarProveedor() {
       navigate('/dashboard/proveedores');
     } catch (error) {
       console.error(error);
-      alert('Error al actualizar proveedor');
+      showNotification('error', 'Error al actualizar proveedor');
     }
   };
 

--- a/frontend/src/pages/proveedores/NuevoProveedor.jsx
+++ b/frontend/src/pages/proveedores/NuevoProveedor.jsx
@@ -4,9 +4,11 @@ import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 import { useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 
 function NuevoProveedor() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const navigate = useNavigate();
 
   const crearProveedor = async (datos) => {
@@ -17,7 +19,7 @@ function NuevoProveedor() {
       navigate('/dashboard/proveedores');
     } catch (error) {
       console.error(error);
-      alert('Error al crear proveedor');
+      showNotification('error', 'Error al crear proveedor');
     }
   };
 

--- a/frontend/src/pages/proveedores/Proveedores.jsx
+++ b/frontend/src/pages/proveedores/Proveedores.jsx
@@ -1,11 +1,13 @@
 // Listado de proveedores obtenido desde /api/proveedores.
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { Link } from 'react-router-dom';
 
 function Proveedores() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [proveedores, setProveedores] = useState([]);
 
   useEffect(() => {
@@ -33,7 +35,7 @@ function Proveedores() {
       setProveedores(prev => prev.filter(p => p._id !== id));
     } catch (error) {
       console.error(error);
-      alert('Error al eliminar proveedor');
+      showNotification('error', 'Error al eliminar proveedor');
     }
   };
 

--- a/frontend/src/pages/tareas/DetalleTarea.jsx
+++ b/frontend/src/pages/tareas/DetalleTarea.jsx
@@ -2,10 +2,12 @@ import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 
 function DetalleTarea() {
   const { id } = useParams();
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [tarea, setTarea] = useState(null);
   const [comentario, setComentario] = useState('');
 
@@ -31,7 +33,7 @@ function DetalleTarea() {
       setComentario('');
       obtenerTarea();
     } catch (error) {
-      alert('Error al comentar');
+      showNotification('error', 'Error al comentar');
     }
   };
 

--- a/frontend/src/pages/tareas/Tareas.jsx
+++ b/frontend/src/pages/tareas/Tareas.jsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import FormularioTarea from '../../components/FormularioTarea';
 import { Link } from 'react-router-dom';
 
@@ -8,6 +9,7 @@ const estados = ['pendiente', 'en_progreso', 'completada', 'cancelada'];
 
 function Tareas() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [tareas, setTareas] = useState([]);
   const [mostrarFormulario, setMostrarFormulario] = useState(false);
 
@@ -34,7 +36,7 @@ function Tareas() {
       setMostrarFormulario(false);
       obtenerTareas();
     } catch (error) {
-      alert('Error al crear tarea');
+      showNotification('error', 'Error al crear tarea');
     }
   };
 

--- a/frontend/src/pages/usuarios/EditarUsuario.jsx
+++ b/frontend/src/pages/usuarios/EditarUsuario.jsx
@@ -3,6 +3,7 @@ import { useContext, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 
 function EditarUsuario() {
   const { id } = useParams();
@@ -15,7 +16,7 @@ function EditarUsuario() {
     rol: 'ventas',
   });
 
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -45,17 +46,17 @@ function EditarUsuario() {
   const handleSubmit = async e => {
     e.preventDefault();
     setError('');
-    setMensaje('');
 
     try {
       await clienteAxios.put(`/usuarios/${id}`, formulario, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      setMensaje('✅ Usuario actualizado correctamente');
-      setTimeout(() => navigate('/dashboard/usuarios'), 2000);
+      showNotification('success', '✅ Usuario actualizado correctamente');
+      setTimeout(() => navigate('/dashboard/usuarios'), 1500);
     } catch (error) {
       console.error(error);
       setError('❌ Error al actualizar usuario');
+      showNotification('error', '❌ Error al actualizar usuario');
     }
   };
 
@@ -64,7 +65,6 @@ function EditarUsuario() {
       <div className="bg-white shadow-md rounded-lg p-6">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">Editar Usuario</h2>
 
-        {mensaje && <div className="bg-green-100 text-green-800 p-3 rounded mb-4">{mensaje}</div>}
         {error && <div className="bg-red-100 text-red-800 p-3 rounded mb-4">{error}</div>}
 
         <form onSubmit={handleSubmit} className="space-y-5">

--- a/frontend/src/pages/usuarios/NuevoUsuario.jsx
+++ b/frontend/src/pages/usuarios/NuevoUsuario.jsx
@@ -2,6 +2,7 @@
 import { useState, useContext } from 'react';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import { useNavigate } from 'react-router-dom';
 
 function NuevoUsuario() {
@@ -13,7 +14,7 @@ function NuevoUsuario() {
   });
 
   const [error, setError] = useState('');
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const { token } = useContext(AuthContext);
   const navigate = useNavigate();
 
@@ -24,16 +25,16 @@ function NuevoUsuario() {
   const handleSubmit = async e => {
     e.preventDefault();
     setError('');
-    setMensaje('');
 
     try {
       await clienteAxios.post('/usuarios', formulario, {
         headers: { Authorization: `Bearer ${token}` }
       });
-      setMensaje('✅ Usuario creado correctamente');
-      setTimeout(() => navigate('/dashboard/usuarios'), 2000);
+      showNotification('success', '✅ Usuario creado correctamente');
+      setTimeout(() => navigate('/dashboard/usuarios'), 1500);
     } catch (err) {
       setError(err.response?.data?.mensaje || '❌ Error al crear usuario');
+      showNotification('error', err.response?.data?.mensaje || '❌ Error al crear usuario');
     }
   };
 
@@ -42,7 +43,6 @@ function NuevoUsuario() {
       <div className="bg-white shadow-md rounded-lg p-6">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">Crear nuevo usuario</h2>
 
-        {mensaje && <div className="bg-green-100 text-green-800 p-3 rounded mb-4">{mensaje}</div>}
         {error && <div className="bg-red-100 text-red-800 p-3 rounded mb-4">{error}</div>}
 
         <form onSubmit={handleSubmit} className="space-y-5">

--- a/frontend/src/pages/ventas/EditarVenta.jsx
+++ b/frontend/src/pages/ventas/EditarVenta.jsx
@@ -3,6 +3,7 @@ import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import clienteAxios from '../../api/clienteAxios';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import FormularioVenta from '../../components/FormularioVenta';
 
 function EditarVenta() {
@@ -17,7 +18,7 @@ function EditarVenta() {
     precio: 0
   });
 
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -42,25 +43,24 @@ function EditarVenta() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setMensaje('');
     setError('');
 
     try {
       await clienteAxios.put(`/ventas/${id}`, venta, {
         headers: { Authorization: `Bearer ${token}` }
       });
-      setMensaje('Venta actualizada');
-      setTimeout(() => navigate('/dashboard/ventas'), 2000);
+      showNotification('success', 'Venta actualizada');
+      setTimeout(() => navigate('/dashboard/ventas'), 1500);
     } catch (error) {
       console.error(error);
       setError('Error al actualizar venta');
+      showNotification('error', 'Error al actualizar venta');
     }
   };
 
   return (
     <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
       <h2 className="text-2xl font-bold mb-4">Editar venta</h2>
-      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
       {error && <p className="text-red-600 mb-2">{error}</p>}
       <FormularioVenta venta={venta} setVenta={setVenta} handleSubmit={handleSubmit} esEdicion />
     </div>

--- a/frontend/src/pages/ventas/NuevaVenta.jsx
+++ b/frontend/src/pages/ventas/NuevaVenta.jsx
@@ -1,6 +1,7 @@
 // Formulario para registrar una venta.
 import { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { useNavigate } from 'react-router-dom';
 // Ya no usamos FormularioVenta porque la venta se crea a partir de un presupuesto
@@ -55,12 +56,11 @@ function NuevaVenta() {
     }
   };
 
-  const [mensaje, setMensaje] = useState('');
+  const { showNotification } = useNotification();
   const [error, setError] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setMensaje('');
     setError('');
 
     const datos = {
@@ -78,18 +78,18 @@ function NuevaVenta() {
       await clienteAxios.post('/ventas', datos, {
         headers: { Authorization: `Bearer ${token}` }
       });
-      setMensaje('Venta registrada correctamente');
-      setTimeout(() => navigate('/dashboard/ventas'), 2000);
+      showNotification('success', 'Venta registrada correctamente');
+      setTimeout(() => navigate('/dashboard/ventas'), 1500);
     } catch (error) {
       console.error(error);
       setError('Error al registrar venta');
+      showNotification('error', 'Error al registrar venta');
     }
   };
 
   return (
     <div className="max-w-lg mx-auto mt-10 bg-white p-6 shadow rounded">
       <h2 className="text-2xl font-bold mb-4">Registrar venta</h2>
-      {mensaje && <p className="text-green-600 mb-2">{mensaje}</p>}
       {error && <p className="text-red-600 mb-2">{error}</p>}
 
       <div className="mb-4">

--- a/frontend/src/pages/ventas/Ventas.jsx
+++ b/frontend/src/pages/ventas/Ventas.jsx
@@ -1,11 +1,13 @@
 // Historial de ventas con enlaces para editar.
 import { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '../../context/AuthContext';
+import { useNotification } from '../../context/NotificationContext';
 import clienteAxios from '../../api/clienteAxios';
 import { Link } from 'react-router-dom';
 
 function Ventas() {
   const { token } = useContext(AuthContext);
+  const { showNotification } = useNotification();
   const [ventas, setVentas] = useState([]);
 
   useEffect(() => {
@@ -31,7 +33,7 @@ function Ventas() {
       setVentas(prev => prev.filter(v => v._id !== id));
     } catch (error) {
       console.error(error);
-      alert('Error al eliminar venta');
+      showNotification('error', 'Error al eliminar venta');
     }
   };
 


### PR DESCRIPTION
## Summary
- implement Notification component using Tailwind + framer-motion
- add NotificationProvider with global context
- wrap App with provider
- replace alerts and inline messages with toast notifications across pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886a9e84bb4833399153d1f71943295