### PR TITLE
Add reusable confirm dialog

### DIFF
--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,47 @@
+// Modal reutilizable de confirmación con animaciones
+import { motion, AnimatePresence } from 'framer-motion';
+import PropTypes from 'prop-types';
+
+export default function ConfirmDialog({ message, onConfirm, onCancel }) {
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <motion.div
+          className="bg-white rounded-xl p-6 shadow-xl max-w-sm w-full"
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.8, opacity: 0 }}
+          role="dialog"
+          aria-modal="true"
+        >
+          <p className="mb-6 text-gray-700">{message}</p>
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={onCancel}
+              className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={onConfirm}
+              className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+              Aceptar
+            </button>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+ConfirmDialog.propTypes = {
+  message: PropTypes.node.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};

--- a/frontend/src/context/ConfirmProvider.jsx
+++ b/frontend/src/context/ConfirmProvider.jsx
@@ -1,0 +1,45 @@
+// Proveedor global que maneja los modales de confirmación
+import { createContext, useContext, useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import ConfirmDialog from '../components/ConfirmDialog.jsx';
+
+const ConfirmContext = createContext();
+
+export const ConfirmProvider = ({ children }) => {
+  const [confirmState, setConfirmState] = useState(null); // { message, resolve }
+
+  const confirm = useCallback((message) => {
+    return new Promise(resolve => {
+      setConfirmState({ message, resolve });
+    });
+  }, []);
+
+  const handleCancel = () => {
+    if (confirmState?.resolve) confirmState.resolve(false);
+    setConfirmState(null);
+  };
+
+  const handleConfirm = () => {
+    if (confirmState?.resolve) confirmState.resolve(true);
+    setConfirmState(null);
+  };
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {confirmState && (
+        <ConfirmDialog
+          message={confirmState.message}
+          onCancel={handleCancel}
+          onConfirm={handleConfirm}
+        />
+      )}
+    </ConfirmContext.Provider>
+  );
+};
+
+ConfirmProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useConfirmContext = () => useContext(ConfirmContext);

--- a/frontend/src/hooks/useConfirm.js
+++ b/frontend/src/hooks/useConfirm.js
@@ -1,0 +1,6 @@
+// Hook para utilizar el diálogo de confirmación desde cualquier componente
+import { useConfirmContext } from '../context/ConfirmProvider.jsx';
+
+export default function useConfirm() {
+  return useConfirmContext();
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,15 +5,18 @@ import App from './App.jsx';
 import './index.css';
 import { AuthProvider } from './context/AuthContext.jsx';
 import { NotificationProvider } from './context/NotificationContext.jsx';
+import { ConfirmProvider } from './context/ConfirmProvider.jsx';
 
 
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <NotificationProvider>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <ConfirmProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ConfirmProvider>
     </NotificationProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/clientes/Clientes.jsx
+++ b/frontend/src/pages/clientes/Clientes.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
 import { useNotification } from '../../context/NotificationContext';
+import useConfirm from '../../hooks/useConfirm.js';
 import clienteAxios from '../../api/clienteAxios';
 import { Link } from 'react-router-dom';
 
@@ -9,6 +10,7 @@ import { Link } from 'react-router-dom';
 function Clientes() {
   const { token } = useContext(AuthContext);
   const { showNotification } = useNotification();
+  const confirm = useConfirm();
   const [clientes, setClientes] = useState([]);
 
   useEffect(() => {
@@ -27,7 +29,7 @@ function Clientes() {
   }, [token]);
 
   const handleEliminar = async (id) => {
-    const confirmar = confirm('¿Estás seguro de eliminar este cliente?');
+    const confirmar = await confirm('¿Estás seguro de eliminar este cliente?');
     if (!confirmar) return;
     try {
       await clienteAxios.delete(`/clientes/${id}`, {


### PR DESCRIPTION
## Summary
- implement reusable ConfirmDialog component
- create ConfirmProvider and hook to show confirm modal via promises
- wrap app with ConfirmProvider
- use new confirmation dialog in Clientes page

## Testing
- `npm test`
- `npm run lint --workspace frontend` *(fails: Fast refresh only works...)*

------
https://chatgpt.com/codex/tasks/task_e_6886af6e014083339ae2f6f21fa76d28