### PR TITLE
Add PDF export for Presupuestos

### DIFF
--- a/backend/controllers/presupuestoController.js
+++ b/backend/controllers/presupuestoController.js
@@ -1,5 +1,6 @@
 // Controlador de presupuestos para Presupuestos.jsx
 const Presupuesto = require('../models/Presupuesto');
+const PDFDocument = require('pdfkit');
 
 const obtenerPresupuestos = async (req, res) => {
   try {
@@ -54,10 +55,43 @@ const eliminarPresupuesto = async (req, res) => {
   }
 };
 
+const descargarPDF = async (req, res) => {
+  try {
+    const presupuesto = await Presupuesto.findOne({ _id: req.params.id, empresaId: req.empresaId })
+      .populate('cliente')
+      .populate('productos.producto');
+    if (!presupuesto) return res.status(404).json({ mensaje: 'Presupuesto no encontrado' });
+
+    const doc = new PDFDocument();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename=presupuesto-${presupuesto._id}.pdf`);
+    doc.pipe(res);
+
+    doc.fontSize(20).text('Presupuesto', { align: 'center' });
+    doc.moveDown();
+    if (presupuesto.cliente) {
+      doc.fontSize(12).text(`Cliente: ${presupuesto.cliente.nombre}`);
+    }
+    doc.text(`Fecha: ${presupuesto.createdAt.toISOString().substring(0,10)}`);
+    doc.moveDown();
+
+    presupuesto.productos.forEach(p => {
+      doc.text(`${p.nombre} x ${p.cantidad} - $${p.subtotal.toFixed(2)}`);
+    });
+    doc.moveDown();
+    doc.fontSize(14).text(`Total: $${presupuesto.total.toFixed(2)}`, { align: 'right' });
+
+    doc.end();
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al generar PDF', error: error.message });
+  }
+};
+
 module.exports = {
   obtenerPresupuestos,
   obtenerPresupuesto,
   crearPresupuesto,
   actualizarPresupuesto,
-  eliminarPresupuesto
+  eliminarPresupuesto,
+  descargarPDF
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.3",
     "nodemailer": "^6.9.13",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "pdfkit": "^0.17.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/backend/routes/presupuestos.js
+++ b/backend/routes/presupuestos.js
@@ -7,12 +7,14 @@ const {
   obtenerPresupuesto,
   crearPresupuesto,
   actualizarPresupuesto,
-  eliminarPresupuesto
+  eliminarPresupuesto,
+  descargarPDF
 } = require('../controllers/presupuestoController');
 
 const { verificarToken, permitirRoles } = require('../middleware/authMiddleware');
 
 router.get('/', verificarToken, obtenerPresupuestos);
+router.get('/:id/pdf', verificarToken, descargarPDF);
 router.get('/:id', verificarToken, obtenerPresupuesto);
 router.post('/', verificarToken, permitirRoles('admin', 'ventas'), crearPresupuesto);
 router.put('/:id', verificarToken, permitirRoles('admin', 'ventas'), actualizarPresupuesto);

--- a/backend/tests/presupuestoController.test.js
+++ b/backend/tests/presupuestoController.test.js
@@ -1,0 +1,32 @@
+const presupuestoController = require('../controllers/presupuestoController');
+const Presupuesto = require('../models/Presupuesto');
+
+jest.mock('../models/Presupuesto');
+jest.mock('pdfkit', () => {
+  return jest.fn().mockImplementation(() => ({
+    pipe: jest.fn(),
+    fontSize: jest.fn().mockReturnThis(),
+    text: jest.fn().mockReturnThis(),
+    moveDown: jest.fn().mockReturnThis(),
+    end: jest.fn()
+  }));
+});
+
+describe('descargarPDF', () => {
+  test('busca presupuesto dentro de la empresa', async () => {
+    const presupuestoMock = { _id: '1', productos: [], total: 0, createdAt: new Date(), cliente: { nombre: 'c' } };
+    const query = {
+      populate: jest.fn().mockReturnThis(),
+      then: (resolve) => Promise.resolve(resolve(presupuestoMock))
+    };
+    Presupuesto.findOne.mockReturnValue(query);
+
+    const req = { params: { id: '1' }, empresaId: 'empresa1' };
+    const res = { setHeader: jest.fn() };
+
+    await presupuestoController.descargarPDF(req, res);
+
+    expect(Presupuesto.findOne).toHaveBeenCalledWith({ _id: '1', empresaId: 'empresa1' });
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+  });
+});

--- a/frontend/src/pages/presupuestos/Presupuestos.jsx
+++ b/frontend/src/pages/presupuestos/Presupuestos.jsx
@@ -50,6 +50,24 @@ function Presupuestos() {
     }
   };
 
+  const handleExportarPDF = async (id) => {
+    try {
+      const { data } = await clienteAxios.get(`/presupuestos/${id}/pdf`, {
+        responseType: 'blob',
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      const url = window.URL.createObjectURL(new Blob([data], { type: 'application/pdf' }));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'presupuesto.pdf';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      showNotification('error', 'Error al generar PDF');
+    }
+  };
+
 
   const togglePresupuesto = (id) => {
     setPresupuestoActivo(presupuestoActivo === id ? null : id);
@@ -96,6 +114,10 @@ function Presupuestos() {
               <div className="pt-3 flex justify-between flex-wrap gap-4 text-sm">
                 <button onClick={() => handleEliminar(p._id)} className="text-red-600 hover:underline">
                   Eliminar
+                </button>
+
+                <button onClick={() => handleExportarPDF(p._id)} className="text-green-600 hover:underline">
+                  Descargar PDF
                 </button>
 
                 {p.estado?.trim().toLowerCase() === 'pendiente' && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.3",
         "node-cron": "^3.0.3",
-        "nodemailer": "^6.9.13"
+        "nodemailer": "^6.9.13",
+        "pdfkit": "^0.17.1"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -2813,6 +2814,15 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@swc/types": {
       "version": "0.1.23",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
@@ -4207,6 +4217,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
@@ -4271,6 +4301,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -4611,6 +4650,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4867,6 +4915,12 @@
         "node": ">=4.8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -5121,6 +5175,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5976,7 +6036,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -6102,6 +6161,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/for-each": {
@@ -9391,6 +9467,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9847,6 +9929,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -10710,6 +10811,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10833,6 +10940,19 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -10974,6 +11094,11 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -11437,6 +11562,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -12308,6 +12439,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -12617,6 +12754,26 @@
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/universalify": {
       "version": "0.2.0",


### PR DESCRIPTION
## Summary
- allow generating PDF for presupuestos in backend using pdfkit
- expose `/presupuestos/:id/pdf` route
- support PDF download from the frontend
- cover PDF controller with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68880e8da9a88333bea7cbf5d13c63eb